### PR TITLE
[FIX]: Modal Not Closing In Same Workspace

### DIFF
--- a/src/modules/workspace/components/dialog/select.tsx
+++ b/src/modules/workspace/components/dialog/select.tsx
@@ -1,6 +1,7 @@
 import { Divider, HStack, Text, VStack } from '@chakra-ui/react';
 
 import { Dialog, SquarePlusIcon } from '@/components';
+import { CookieName, CookiesConfig } from '@/config/cookies';
 import { Workspace } from '@/modules/core';
 
 import { UseWorkspaceReturn } from '../../hooks';
@@ -21,6 +22,10 @@ const SelectWorkspaceDialog = ({
   onCreate,
 }: SelectWorkspaceDialogProps) => {
   const listIsEmpty = userWorkspaces.length === 0;
+
+  const loggedWorkspace = JSON.parse(
+    CookiesConfig.getCookie(CookieName.WORKSPACE)!,
+  ).id;
 
   return (
     <Dialog.Modal
@@ -61,7 +66,9 @@ const SelectWorkspaceDialog = ({
                   key={w.id}
                   workspace={w}
                   counter={{ members: w.members.length, vaults: w.predicates }}
-                  onClick={() => onSelect(w)}
+                  onClick={() => {
+                    w.id !== loggedWorkspace ? onSelect(w) : dialog.onClose();
+                  }}
                 />
               ))
             )}


### PR DESCRIPTION
**O que foi feito:**

- Foi pego o `workspace` logado e passado como verificação no `onClick` do botão do modal.
  - Caso seja o mesmo `id` ele fecha o modal, caso seja diferente, ele redireciona.

**Como testar:**
- Clique em `workspaces` e mude para algum workspace, depois tente mudar para o mesmo workspace novamente e verifique se o modal fechou.


[`Task`](https://app.clickup.com/t/86a24h3a0)