### PR TITLE
[FIX]: Home Transactions only working after refresh

### DIFF
--- a/src/modules/transactions/hooks/signature/useSignTransaction.ts
+++ b/src/modules/transactions/hooks/signature/useSignTransaction.ts
@@ -8,6 +8,7 @@ import {
   invalidateQueries,
   useWalletSignMessage,
 } from '@/modules/core';
+import { useHome } from '@/modules/home';
 import { VAULT_TRANSACTIONS_QUERY_KEY } from '@/modules/vault';
 
 import { useTransactionSend } from '../../providers';
@@ -33,6 +34,7 @@ const useSignTransaction = (options: UseSignTransactionOptions) => {
   const toast = useTransactionToast();
   const { account } = useFuelAccount();
   const transactionSendContext = useTransactionSend();
+  const { transactionsRequest } = useHome();
 
   useMemo(() => {
     const transaction = options.transaction;
@@ -48,19 +50,22 @@ const useSignTransaction = (options: UseSignTransactionOptions) => {
     return options.transaction;
   }, [options.transaction]);
 
-  const refetetchTransactionList = () => {
+  const refetchTransactionList = () => {
     invalidateQueries([
       'bsafe',
-      ...HomeQueryKey.FULL_DATA(),
       TRANSACTION_LIST_QUERY_KEY,
       USER_TRANSACTIONS_QUERY_KEY,
       VAULT_TRANSACTIONS_QUERY_KEY,
       TRANSACTION_LIST_PAGINATION_QUERY_KEY,
+      ...HomeQueryKey.FULL_DATA(),
     ]);
   };
 
   const request = useSignTransactionRequest({
-    onSuccess: () => refetetchTransactionList(),
+    onSuccess: () => {
+      refetchTransactionList();
+      transactionsRequest.refetch();
+    },
     onError: () => {
       toast.generalError(randomBytes.toString(), 'Inválid signature');
     },


### PR DESCRIPTION
**O que foi feito:**

- Foi adicionado um `refetch` nas transactions da `Home` após fazer um `Sign` na transaction