### PR TITLE
[FIX]: Transactions Filter By Id

### DIFF
--- a/src/modules/core/models/workspace.ts
+++ b/src/modules/core/models/workspace.ts
@@ -120,12 +120,14 @@ export const WorkspacesQueryKey = {
     workspaceId: string,
     status?: string,
     vaultId?: string,
+    id?: string,
   ) => [
     WorkspacesQueryKey.DEFAULT,
     'transaction-list-pagination',
     workspaceId,
     vaultId,
     status,
+    id,
   ],
   PENDING_TRANSACTIONS: (workspaceId: string, vaultId?: string) => [
     WorkspacesQueryKey.DEFAULT,

--- a/src/modules/transactions/hooks/list/useTransactionList.ts
+++ b/src/modules/transactions/hooks/list/useTransactionList.ts
@@ -32,7 +32,7 @@ const useTransactionList = () => {
   const vaultAssets = useVaultAssets(vaultRequest.predicateInstance);
   const transactionRequest = useTransactionListPaginationRequest({
     predicateId: params.vaultId ? [params.vaultId] : undefined,
-    ...(selectedTransaction?.id ? { id: selectedTransaction.id } : {}),
+    id: selectedTransaction.id,
     /* TODO: Change logic this */
     status: filter ? [filter] : undefined,
   });

--- a/src/modules/transactions/hooks/list/useTransactionListPaginationRequest.ts
+++ b/src/modules/transactions/hooks/list/useTransactionListPaginationRequest.ts
@@ -28,6 +28,7 @@ const useTransactionListPaginationRequest = (
       current,
       params.status as StatusFilter,
       params.predicateId?.[0],
+      params.id,
     ),
     ({ pageParam }) =>
       TransactionService.getTransactionsPagination({
@@ -36,6 +37,7 @@ const useTransactionListPaginationRequest = (
         page: pageParam || 0,
         orderBy: 'createdAt',
         sort: SortOption.DESC,
+        id: params.id,
       }),
     {
       onSuccess: () => invalidateQueries([PENDING_TRANSACTIONS_QUERY_KEY]),


### PR DESCRIPTION
**O que foi feito:**

- Foi adicionado como `queryKey` o `ID` da transaction, para que cada vez que for mudado o id, ele atualizar o cache.