### PR TITLE
fix(webauthn): eip2090_encode function now receives a copy of signatureCompact

### DIFF
--- a/src/modules/core/utils/webauthn/crypto.ts
+++ b/src/modules/core/utils/webauthn/crypto.ts
@@ -74,13 +74,11 @@ export function getSignature(
   )
     .normalizeS()
     .toCompactRawBytes();
+  const recoveryBit = getRecoveryBit(publicKey, signatureCompact, digest);
+  const sigatureCompactCopy = new Uint8Array(signatureCompact.slice());
+
   return {
-    signature: hexlify(
-      EIP2090_encode(
-        signatureCompact,
-        getRecoveryBit(publicKey, signatureCompact, digest),
-      ),
-    ),
+    signature: hexlify(EIP2090_encode(sigatureCompactCopy, recoveryBit)),
     digest: hexlify(digest),
     sig_compact: signatureCompact,
     dig_compact: digest,


### PR DESCRIPTION
- O bug acontecia pois a função EIP2090_encode fazia alterações na mesma referencia da variavel signatureCompact que era enviada para API. Para resolver isso foi criada uma cópia de signatureCompact e essa cópia é passada como parametro para a função EIP2090_encode.

https://app.clickup.com/t/86a2pdtm1