### PR TITLE
FIX: Transaction cards / grid

### DIFF
--- a/src/modules/home/pages/home.tsx
+++ b/src/modules/home/pages/home.tsx
@@ -11,6 +11,7 @@ import {
   useDisclosure,
   VStack,
 } from '@chakra-ui/react';
+import format from 'date-fns/format';
 import { FaRegPlusSquare } from 'react-icons/fa';
 import { MdKeyboardArrowRight } from 'react-icons/md';
 
@@ -330,17 +331,19 @@ const HomePage = () => {
                               vault={transaction.predicate}
                             />
                           )}
-                          {/* <TransactionCard.CreationDate>
+                          <TransactionCard.CreationDate>
                             {format(
                               new Date(transaction.createdAt),
                               'EEE, dd MMM',
                             )}
-                          </TransactionCard.CreationDate> */}
+                          </TransactionCard.CreationDate>
                           <TransactionCard.Assets />
                           <TransactionCard.Amount
                             assets={transaction.resume.outputs}
                           />
-                          <TransactionCard.Name vaultName={transaction.name} />
+                          <TransactionCard.Name
+                            transactionName={transaction.name}
+                          />
                           <TransactionCard.Status
                             transaction={transaction}
                             status={transactionStatus({

--- a/src/modules/transactions/components/TransactionCard/Container.tsx
+++ b/src/modules/transactions/components/TransactionCard/Container.tsx
@@ -57,12 +57,12 @@ const Container = ({
   const gridTemplateColumns = isMobile
     ? 'repeat(2, 1fr)'
     : isInTheVaultWithSideBar
-      ? 'repeat(4, 1fr)'
-      : isInTheVaultWithoutSideBar && childrensQuantity < 5
+      ? 'repeat(5, 1fr)'
+      : isInTheVaultWithoutSideBar && childrensQuantity < 6
         ? 'repeat(4, 1fr)'
-        : isInTheVaultWithoutSideBar && childrensQuantity >= 5
-          ? 'repeat(4,1fr)'
-          : 'repeat(5,1fr)';
+        : isInTheVaultWithoutSideBar && childrensQuantity >= 6
+          ? 'repeat(5,1fr)'
+          : 'repeat(6,1fr)';
 
   return (
     <>

--- a/src/modules/transactions/components/TransactionCard/Details.tsx
+++ b/src/modules/transactions/components/TransactionCard/Details.tsx
@@ -259,33 +259,7 @@ const Details = ({
   return (
     <DetailsTransactionStepper transactionId={transaction.id}>
       {(isLoading, transactionHistory) => (
-        <CustomSkeleton
-          py={2}
-          isLoaded={!isLoading && !!transactionHistory}
-          // h={
-          //   isMobile && isMdHeight
-          //     ? 360
-          //     : isMobile && !isMdHeight
-          //       ? 500
-          //       : 'unset'
-          // }
-          // sx={{
-          //   '&::-webkit-scrollbar': {
-          //     display: 'none',
-          //     width: '5px',
-          //     maxHeight: '330px',
-          //     backgroundColor: 'transparent',
-          //     borderRadius: '30px',
-          //   },
-          //   '&::-webkit-scrollbar-thumb': {
-          //     backgroundColor: '#2C2C2C',
-          //     borderRadius: '30px',
-          //     height: '10px',
-          //   },
-          // }}
-          // overflowY={isMobile ? 'scroll' : 'unset'}
-          // overflowX={isMobile ? 'hidden' : 'unset'}
-        >
+        <CustomSkeleton py={2} isLoaded={!isLoading && !!transactionHistory}>
           <VStack w="full">
             <Stack
               pt={{ base: 0, sm: 5 }}

--- a/src/modules/transactions/components/TransactionCard/DetailsDialog.tsx
+++ b/src/modules/transactions/components/TransactionCard/DetailsDialog.tsx
@@ -5,6 +5,7 @@ import {
   HStack,
   VStack,
 } from '@chakra-ui/react';
+import format from 'date-fns/format';
 
 import { Dialog, DialogModalProps } from '@/components';
 import { TransactionState } from '@/modules/core/models/transaction';
@@ -56,13 +57,13 @@ const DetailsDialog = ({ ...props }: DetailsDialogProps) => {
                 }
               />
 
-              {/* <TransactionCard.CreationDate>
+              <TransactionCard.CreationDate>
                 {format(new Date(transaction?.createdAt), 'EEE, dd MMM')}
-              </TransactionCard.CreationDate> */}
+              </TransactionCard.CreationDate>
             </HStack>
 
             <HStack w="full" justifyContent="space-between">
-              <TransactionCard.Name vaultName={transaction.name} />
+              <TransactionCard.Name transactionName={transaction.name} />
 
               <TransactionCard.Status
                 transaction={transaction}

--- a/src/modules/transactions/components/TransactionCard/Name.tsx
+++ b/src/modules/transactions/components/TransactionCard/Name.tsx
@@ -1,54 +1,18 @@
 import { Center, Heading, HStack, Text } from '@chakra-ui/react';
 
 import { useScreenSize } from '@/modules/core/hooks';
+import { limitCharacters } from '@/utils';
 
 interface TransactionCardNameProps {
-  vaultName: string;
   showTransaction?: boolean;
+  transactionName?: string;
 }
 
 const Name = ({
-  vaultName,
   showTransaction = true,
+  transactionName,
 }: TransactionCardNameProps) => {
   const { isMobile } = useScreenSize();
-
-  if (isMobile) {
-    return (
-      <Center alignItems="flex-start" flexDir="column" width="80%">
-        <HStack w="100%">
-          <Heading
-            variant={isMobile ? 'title-sm' : 'title-md'}
-            color="grey.200"
-            textOverflow="ellipsis"
-            textAlign="left"
-            noOfLines={1}
-          >
-            <Text
-              w="100%"
-              style={{
-                overflow: 'hidden',
-                whiteSpace: 'nowrap',
-                textOverflow: 'ellipsis',
-              }}
-            >
-              {vaultName}
-            </Text>
-          </Heading>
-        </HStack>
-        {showTransaction && (
-          <Text
-            variant="description"
-            textAlign="left"
-            fontSize={{ base: 'xs', sm: 'sm' }}
-            color="grey.500"
-          >
-            Transaction
-          </Text>
-        )}
-      </Center>
-    );
-  }
 
   return (
     <Center
@@ -65,7 +29,7 @@ const Name = ({
           textAlign="left"
           noOfLines={1}
         >
-          {vaultName}
+          {limitCharacters(String(transactionName) ?? '', 8)}
         </Heading>
       </HStack>
       {showTransaction && (

--- a/src/modules/transactions/components/TransactionCard/Status.tsx
+++ b/src/modules/transactions/components/TransactionCard/Status.tsx
@@ -39,10 +39,9 @@ const Status = ({
 
   return (
     <HStack
-      w={{ base: '10%', sm: '10%' }}
       justifyContent={{ base: 'flex-end', sm: 'center' }}
       ml={{ base: 0, sm: 6 }}
-      // maxW="full"
+      maxW="full"
     >
       {isLoading && (
         <CircularProgress

--- a/src/modules/transactions/components/TransactionCard/VaultInfo.tsx
+++ b/src/modules/transactions/components/TransactionCard/VaultInfo.tsx
@@ -12,59 +12,8 @@ interface TransactionVaultInfoProps {
 const VaultInfo = ({ vault }: TransactionVaultInfoProps) => {
   const { isMobile } = useScreenSize();
 
-  if (isMobile) {
-    return (
-      <HStack w="80%">
-        <Avatar
-          variant="roundedSquare"
-          name={vault.name}
-          color="white"
-          bg="grey.600"
-          w={50}
-          h={50}
-        />
-        <VStack ml={1} alignItems="flex-start" spacing={0} w="90%">
-          {!vault.workspace.single && (
-            <HStack w="100%">
-              <Icon
-                as={HandbagIcon}
-                fontSize={{ base: 'xs', sm: 14 }}
-                color="grey.200"
-              />
-              <Text
-                color="grey.200"
-                fontSize={{ base: 'sm', sm: 'xs', md: 'md' }}
-                w="80%"
-                style={{
-                  overflow: 'hidden',
-                  whiteSpace: 'nowrap',
-                  textOverflow: 'ellipsis',
-                }}
-              >
-                {vault.workspace?.name}
-              </Text>
-            </HStack>
-          )}
-          <Heading
-            w="80%"
-            variant={isMobile ? 'title-sm' : 'title-md'}
-            color="grey.200"
-            mt={0}
-            style={{
-              overflow: 'hidden',
-              whiteSpace: 'nowrap',
-              textOverflow: 'ellipsis',
-            }}
-          >
-            {vault.name}
-          </Heading>
-        </VStack>
-      </HStack>
-    );
-  }
-
   return (
-    <HStack w={250}>
+    <HStack w={180}>
       <Avatar
         variant="roundedSquare"
         name={vault.name}
@@ -76,17 +25,16 @@ const VaultInfo = ({ vault }: TransactionVaultInfoProps) => {
       />
       <VStack ml={1} alignItems="flex-start" spacing={0}>
         {!vault.workspace.single && (
-          <HStack spacing={1}>
+          <HStack>
             <Icon
               as={HandbagIcon}
               fontSize={{ base: 'xs', sm: 14 }}
               color="grey.200"
             />
             <Text
-              maxW="80%"
-              // w={{ base: 100, sm: '100%', md: 140, mxs: 200 }}
+              maxW={24}
               color="grey.200"
-              fontSize={{ base: 'sm', sm: 'xs', md: 'md' }}
+              fontSize={{ base: 'xs', sm: 'sm' }}
               isTruncated
             >
               {vault.workspace?.name}

--- a/src/modules/transactions/components/transactionCardMobile/index.tsx
+++ b/src/modules/transactions/components/transactionCardMobile/index.tsx
@@ -1,4 +1,5 @@
 import { Card, CardProps, Divider, HStack } from '@chakra-ui/react';
+import format from 'date-fns/format';
 
 import { useDetailsDialog } from '../../hooks/details';
 import { TransactionWithVault } from '../../services';
@@ -43,7 +44,7 @@ const TransactionCardMobile = (props: TransactionCardMobileProps) => {
       />
 
       <Card
-        bgColor={missingSignature ? 'warning.800' : 'grey.800'}
+        bgColor="grey.800"
         borderColor={missingSignature ? 'warning.500' : 'dark.100'}
         borderWidth="1px"
         onClick={onOpen}
@@ -52,7 +53,7 @@ const TransactionCardMobile = (props: TransactionCardMobileProps) => {
         {...rest}
       >
         <HStack justifyContent="space-between">
-          <TransactionCard.Name vaultName={transaction.name} />
+          <TransactionCard.Name transactionName={transaction.name} />
 
           <TransactionCard.Status
             transaction={transaction}
@@ -61,14 +62,14 @@ const TransactionCardMobile = (props: TransactionCardMobileProps) => {
           />
         </HStack>
 
-        <HStack mt={2} justifyContent="space-between">
+        <HStack mt={2}>
           {transaction.predicate && (
             <TransactionCard.VaultInfo vault={transaction.predicate} />
           )}
 
-          {/* <TransactionCard.CreationDate>
+          <TransactionCard.CreationDate>
             {format(new Date(transaction.createdAt), 'EEE, dd MMM')}
-          </TransactionCard.CreationDate> */}
+          </TransactionCard.CreationDate>
         </HStack>
 
         <Divider bgColor="grey.600" />

--- a/src/modules/transactions/pages/list/index.tsx
+++ b/src/modules/transactions/pages/list/index.tsx
@@ -11,6 +11,7 @@ import {
   useDisclosure,
 } from '@chakra-ui/react';
 import { TransactionStatus } from 'bakosafe';
+import format from 'date-fns/format';
 import { RiMenuUnfoldLine } from 'react-icons/ri';
 
 import { CustomSkeleton, HomeIcon, LineCloseIcon } from '@/components';
@@ -240,16 +241,16 @@ const TransactionsVaultPage = () => {
                     isInTheVaultPage
                     callBack={() => filter.set(StatusFilter.ALL)}
                   >
-                    {/* {!isMobile && (
+                    {!isMobile && (
                       <TransactionCard.CreationDate>
                         {format(new Date(transaction.createdAt), 'EEE, dd MMM')}
                       </TransactionCard.CreationDate>
-                    )} */}
+                    )}
                     <TransactionCard.Assets />
                     <TransactionCard.Amount
                       assets={transaction.resume.outputs}
                     />
-                    <TransactionCard.Name vaultName={transaction.name} />
+                    <TransactionCard.Name transactionName={transaction.name} />
 
                     <TransactionCard.Status
                       transaction={transaction}

--- a/src/modules/transactions/pages/user-transactions/index.tsx
+++ b/src/modules/transactions/pages/user-transactions/index.tsx
@@ -11,6 +11,7 @@ import {
   useDisclosure,
   VStack,
 } from '@chakra-ui/react';
+import format from 'date-fns/format';
 import { FaRegPlusSquare } from 'react-icons/fa';
 import { IoChevronBack } from 'react-icons/io5';
 
@@ -299,14 +300,14 @@ const UserTransactionsPage = () => {
                         vault={transaction.predicate}
                       />
                     )}
-                    {/* <TransactionCard.CreationDate>
+                    <TransactionCard.CreationDate>
                       {format(new Date(transaction.createdAt), 'EEE, dd MMM')}
-                    </TransactionCard.CreationDate> */}
+                    </TransactionCard.CreationDate>
                     <TransactionCard.Assets />
                     <TransactionCard.Amount
                       assets={transaction.resume.outputs}
                     />
-                    <TransactionCard.Name vaultName={transaction.name} />
+                    <TransactionCard.Name transactionName={transaction.name} />
                     <TransactionCard.Status
                       transaction={transaction}
                       status={transactionStatus({ ...transaction, account })}

--- a/src/modules/vault/pages/details/index.tsx
+++ b/src/modules/vault/pages/details/index.tsx
@@ -8,6 +8,7 @@ import {
   Icon,
   Text,
 } from '@chakra-ui/react';
+import format from 'date-fns/format';
 import { RiMenuUnfoldLine } from 'react-icons/ri';
 
 import { CustomSkeleton, HomeIcon } from '@/components';
@@ -239,14 +240,14 @@ const VaultDetailsPage = () => {
                     account={account}
                     isSigner={isSigner}
                   >
-                    {/* {!vaultRequiredSizeToColumnLayout && (
+                    {!vaultRequiredSizeToColumnLayout && (
                       <TransactionCard.CreationDate>
                         {format(
                           new Date(transaction?.createdAt),
                           'EEE, dd MMM',
                         )}
                       </TransactionCard.CreationDate>
-                    )} */}
+                    )}
 
                     <TransactionCard.Assets />
                     <TransactionCard.Amount
@@ -258,7 +259,7 @@ const VaultDetailsPage = () => {
                         })) ?? []
                       }
                     />
-                    <TransactionCard.Name vaultName={transaction.name} />
+                    <TransactionCard.Name transactionName={transaction.name} />
                     <TransactionCard.Status
                       transaction={transaction}
                       status={transactionStatus({

--- a/src/modules/workspace/pages/home/index.tsx
+++ b/src/modules/workspace/pages/home/index.tsx
@@ -21,6 +21,7 @@ import {
   VStack,
 } from '@chakra-ui/react';
 import { ITransaction, IWitnesses } from 'bakosafe';
+import format from 'date-fns/format';
 import { FaRegPlusSquare } from 'react-icons/fa';
 import { IoChevronBack } from 'react-icons/io5';
 import { Outlet } from 'react-router-dom';
@@ -700,14 +701,16 @@ const WorkspacePage = () => {
                           vault={transaction.predicate}
                         />
                       )}
-                      {/* <TransactionCard.CreationDate>
+                      <TransactionCard.CreationDate>
                         {format(new Date(transaction.createdAt), 'EEE, dd MMM')}
-                      </TransactionCard.CreationDate> */}
+                      </TransactionCard.CreationDate>
                       <TransactionCard.Assets />
                       <TransactionCard.Amount
                         assets={transaction.resume.outputs}
                       />
-                      <TransactionCard.Name vaultName={transaction.name} />
+                      <TransactionCard.Name
+                        transactionName={transaction.name}
+                      />
                       <TransactionCard.Status
                         transaction={transaction as unknown as ITransaction}
                         status={transactionStatus({


### PR DESCRIPTION
 - Aberto em draft para ser testado
 
 - Transactions card (1024px pra baixo) mobile, tanto fora quanto dentro do vault
 - Limitar nome do wk no transaction card
 - Ajuste do fundo do card quando está pendente de assinatura, na home
 - Ajuste no espaçamento entre o ícone e o nome do wk no transaction card