### PR TITLE
fix(workspaces): redirect to correct page when update a member and click on add another member

### DIFF
--- a/src/modules/workspace/hooks/members/useChangeMember.ts
+++ b/src/modules/workspace/hooks/members/useChangeMember.ts
@@ -1,11 +1,12 @@
 import { useMemo, useState } from 'react';
-import { useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 
 import { useAddressBook } from '@/modules/addressBook';
 import {
   defaultPermissions,
   EnumUtils,
   Member,
+  Pages,
   PermissionRoles,
   useTab,
   Workspace,
@@ -37,6 +38,8 @@ interface MemberPermission {
 export type UseChangeMember = ReturnType<typeof useChangeMember>;
 
 const useChangeMember = () => {
+  const navigate = useNavigate();
+
   const { goWorkspace } = useWorkspace();
   const { successToast } = useSettingsToast();
 
@@ -188,12 +191,22 @@ const useChangeMember = () => {
 
   const clearSteps = () => {
     tabs.set(MemberTabState.FORM);
-    memberForm.setValue('address', { value: '' });
-    permissionForm.setValue('permission', '');
+    memberForm.reset();
+    permissionForm.reset();
+    editForm.reset();
+    isEditMember && redirectToAddMember();
   };
 
   const clearTabs = () => {
     tabs.set(MemberTabState.FORM);
+  };
+
+  const redirectToAddMember = () => {
+    navigate(
+      Pages.membersWorkspace({
+        workspaceId: params.workspaceId ?? '',
+      }),
+    );
   };
 
   const formState = {

--- a/src/modules/workspace/hooks/members/useChangeMember.ts
+++ b/src/modules/workspace/hooks/members/useChangeMember.ts
@@ -103,10 +103,11 @@ const useChangeMember = () => {
 
   const handlePermissions = permissionForm.handleSubmit((data) => {
     const memberAddress = memberForm.getValues('address.value');
+    const updatedMemberPermission = editForm.getValues('permission');
     const permission = data.permission as PermissionRoles;
 
-    // If has memberAddress it means that comes from the memberForm(creation)
-    if (memberAddress) {
+    // If not has an updated member permission and has a memberAddress it means that comes from the memberForm(creation)
+    if (!updatedMemberPermission && memberAddress) {
       memberRequest.mutate(memberAddress, {
         onSettled: (data?: Workspace) => {
           workspaceRequest.refetch().then(() => {
@@ -136,8 +137,10 @@ const useChangeMember = () => {
     const member = workspace.members.find(
       (member) => member.address === memberAddress,
     );
-    // If !member and !memberAddress it means that comes from the editForm
-    if (!member) return;
+
+    // If not has an updated member permission or not has a member it means that comes from the editForm
+    if (!updatedMemberPermission || !member) return;
+
     permissionsRequest.mutate(
       {
         member: member.id,
@@ -193,8 +196,11 @@ const useChangeMember = () => {
     tabs.set(MemberTabState.FORM);
     memberForm.reset();
     permissionForm.reset();
-    editForm.reset();
-    isEditMember && redirectToAddMember();
+
+    if (isEditMember) {
+      editForm.reset();
+      redirectToAddMember();
+    }
   };
 
   const clearTabs = () => {


### PR DESCRIPTION
- Redirect to Add Member page when update a member and click on add another member
- Reset forms to:
       - disable Add member button when redirect to Add Member page
       - not trigger address field validation when redirect to Add Member page
       
https://app.clickup.com/t/86a3u66r4