### PR TITLE
FIX: Connector useTransactionSummary request.

### DIFF
--- a/src/modules/dapp/hooks/useTransactionSummary.ts
+++ b/src/modules/dapp/hooks/useTransactionSummary.ts
@@ -14,6 +14,17 @@ const useTransactionSummary = () => {
       await delay(600);
       return FuelTransactionService.simulate(params);
     },
+
+    retry: (failureCount, error) => {
+      console.log('GET_SUMMARY_ERROR:', error);
+      console.log('FAILURE_COUNT:', failureCount);
+      if (failureCount >= 1 && failureCount < 3) {
+        console.log('ACTVATING_RETRY_MUTATION');
+        return true; // Do the retry
+      }
+      return false; // Do not retry
+    },
+    retryDelay: 1000 * 60 * 1, // 1 min delay
   });
 
   return {

--- a/src/modules/workspace/WorkspaceProvider.tsx
+++ b/src/modules/workspace/WorkspaceProvider.tsx
@@ -1,8 +1,9 @@
 import { createContext, useContext } from 'react';
 
-import { useWorkspaceDetails } from './hooks/details/useWorkspaceDetails';
 import { BakoLoading } from '@/components';
 import { currentPath } from '@/utils';
+
+import { useWorkspaceDetails } from './hooks/details/useWorkspaceDetails';
 
 export type IWorkspaceContext = ReturnType<typeof useWorkspaceDetails>;
 
@@ -14,7 +15,6 @@ const WorkspaceProvider = ({ children }: { children: React.ReactNode }) => {
 
   return (
     <WorkspaceContext.Provider value={workspaceDetails}>
-      {/* {workspaceDetails.isWorkspaceReady ? children : <BakoLoading />} */}
       {workspaceDetails.isWorkspaceReady || isFromDapp ? (
         children
       ) : (
@@ -36,4 +36,4 @@ const useWorkspaceContext = () => {
   return context;
 };
 
-export { WorkspaceProvider, useWorkspaceContext };
+export { useWorkspaceContext, WorkspaceProvider };


### PR DESCRIPTION
This is a complement for this task: https://app.clickup.com/t/86a4r7efn

In some times, the useTransactionSummary requests returns an error `failed to fetch.` and the user needs to close the window and open it again.  The `retry` logic is to avoid this. 
Although after the changes in `useTransactionSocket` file, this error never showed up again. 