### PR TITLE
FIX: Deposit Card from Contract Call

### DIFF
--- a/src/modules/dapp/components/transaction/operation.tsx
+++ b/src/modules/dapp/components/transaction/operation.tsx
@@ -1,6 +1,7 @@
 import { Box, HStack, VStack } from '@chakra-ui/react';
 import { AddressType } from '@fuel-ts/providers';
 import { Vault } from 'bakosafe';
+import { bn, Operation } from 'fuels';
 
 import { CustomSkeleton } from '@/components';
 import { assetsMap } from '@/modules/core/utils';
@@ -8,11 +9,9 @@ import { DappTransactionAsset } from '@/modules/dapp/components/transaction/asse
 import { DappTransactionFromTo } from '@/modules/dapp/components/transaction/from-to';
 import { RecipientCard } from '@/modules/dapp/components/transaction/recipient';
 
-import { IOutput } from '../../services/fuel-transaction';
-
 interface OperationProps {
   vault?: Pick<Vault['BakoSafeVault'], 'name' | 'predicateAddress'>;
-  operation?: IOutput;
+  operation?: Operation;
 }
 
 export const DappTransactionOperationSekeleton = () => (
@@ -36,17 +35,17 @@ export const DappTransactionOperationSekeleton = () => (
 );
 
 const DappTransactionOperation = ({ vault, operation }: OperationProps) => {
-  const { to, assetId, amount } = operation ?? {};
+  const { to, assetsSent } = operation ?? {};
 
-  if (!to || !assetId || !amount || !vault) return null;
+  if (!to || !assetsSent || !vault) return null;
 
-  const assetData = assetsMap[assetId];
+  const assetData = assetsMap[assetsSent[0].assetId];
 
   const assets = [
     {
       icon: assetData.icon,
-      amount,
-      assetId,
+      amount: bn(assetsSent[0].amount ?? '').format(),
+      assetId: assetsSent[0].assetId,
       name: assetData.name,
       slug: assetData.slug,
     },

--- a/src/modules/dapp/hooks/useTransactionSocket.ts
+++ b/src/modules/dapp/hooks/useTransactionSocket.ts
@@ -45,6 +45,7 @@ export const useTransactionSocket = () => {
     summary.getTransactionSummary({
       transactionLike: tx,
       from: vault.address,
+      providerUrl: vault.provider,
     });
   };
 

--- a/src/modules/dapp/pages/transactionConfirm.tsx
+++ b/src/modules/dapp/pages/transactionConfirm.tsx
@@ -16,9 +16,9 @@ import { Dapp } from '@/layouts/dapp';
 import { useQueryParams } from '@/modules/auth';
 import { DappError, DappTransaction } from '@/modules/dapp/components';
 import { VaultDrawerBox } from '@/modules/vault/components/drawer/box';
+import { useWorkspaceContext } from '@/modules/workspace/WorkspaceProvider';
 
 import { useTransactionSocket, useVerifyBrowserType } from '../hooks';
-import { useWorkspaceContext } from '@/modules/workspace/WorkspaceProvider';
 
 const TransactionConfirm = () => {
   const {

--- a/src/modules/dapp/services/fuel-transaction.ts
+++ b/src/modules/dapp/services/fuel-transaction.ts
@@ -3,17 +3,17 @@ import {
   getTransactionSummaryFromRequest,
   OperationTransactionAddress,
   OutputType,
+  Provider,
   ScriptTransactionRequest,
   TransactionRequestLike,
 } from 'fuels';
 
-import { NativeAssetId } from '@/modules/core';
-import { BaseTransfer, Vault } from 'bakosafe';
 import { authCredentials } from '@/modules';
 
 export interface TransactionSimulateParams {
   transactionLike: TransactionRequestLike;
   from: string;
+  providerUrl: string;
 }
 
 export interface ISent {
@@ -38,7 +38,13 @@ export enum IFuelTransactionNames {
 }
 
 class FuelTransactionService {
-  static async simulate({ transactionLike, from }: TransactionSimulateParams) {
+  static async simulate({
+    transactionLike,
+    from,
+    providerUrl,
+  }: TransactionSimulateParams) {
+    const provider = await Provider.create(providerUrl);
+
     const auth = authCredentials();
     const vault = await Vault.create({
       predicateAddress: from,
@@ -52,71 +58,10 @@ class FuelTransactionService {
       transactionRequest,
     );
 
-    // console.log('auqi', transactionLike.outputs[0].type)
-    //OutputType.Coin
-    /**
-     * tipos de output -> coin, contract
-     *  - coin: deolve um valor para um endereço
-     *  - contract: infos do contrato
-     *
-     *
-     */
-
-    const operations = transactionLike.outputs?.reduce(
-      (acc: IOutput[], output) => {
-        let operation;
-        if (output.type === OutputType.Coin) {
-          operation = {
-            assetId: output.assetId.toString(),
-            type: OutputType.Coin,
-            amount: bn(output.amount).format(),
-            to: {
-              address: output.to.toString(),
-              type: AddressType.account,
-            },
-            from: {
-              type: AddressType.account,
-              address: Address.fromString(from).toHexString(),
-            },
-            name: IFuelTransactionNames.TRANSFER_ASSET,
-            assetsSent: [
-              {
-                amount: bn(output.amount).format(),
-                assetId: output.assetId.toString(),
-              },
-            ],
-          };
-        } else if (output.type === OutputType.Contract) {
-          if (!transactionLike.inputs)
-            throw new Error('Invalid transaction inputs');
-          const isContract =
-            transactionLike.inputs[Number(output.inputIndex)].type ==
-            InputType.Contract;
-          if (!isContract) throw new Error('Invalid contract input');
-          const input = transactionLike.inputs[
-            Number(output.inputIndex)
-          ] as ContractTransactionRequestInput;
-          operation = {
-            calls: [],
-            assetId: NativeAssetId,
-            type: OutputType.Contract,
-            amount: '0.00',
-            to: {
-              address: input.contractId.toString(),
-              type: AddressType.contract,
-            },
-            from: {
-              type: AddressType.account,
-              address: Address.fromString(from).toHexString(),
-            },
-            name: IFuelTransactionNames.CONTRACT_CALL,
-          };
-        }
-        if (operation) acc.push(operation);
-        return acc;
-      },
-      [],
-    );
+    const { operations } = await getTransactionSummaryFromRequest({
+      transactionRequest,
+      provider,
+    });
 
     return {
       fee: transactionRequest.maxFee.format(),

--- a/src/modules/dapp/services/fuel-transaction.ts
+++ b/src/modules/dapp/services/fuel-transaction.ts
@@ -1,9 +1,6 @@
+import { BaseTransfer, Vault } from 'bakosafe';
 import {
-  Address,
-  AddressType,
-  bn,
-  ContractTransactionRequestInput,
-  InputType,
+  getTransactionSummaryFromRequest,
   OperationTransactionAddress,
   OutputType,
   Provider,
@@ -11,7 +8,7 @@ import {
   TransactionRequestLike,
 } from 'fuels';
 
-import { NativeAssetId } from '@/modules/core';
+import { authCredentials } from '@/modules';
 
 export interface TransactionSimulateParams {
   providerUrl: string;
@@ -52,76 +49,27 @@ class FuelTransactionService {
     from,
   }: TransactionSimulateParams) {
     const provider = await Provider.create(providerUrl);
-    const transactionRequest = ScriptTransactionRequest.from(transactionLike);
-    const fee = await provider.getTransactionCost(transactionRequest);
-    // console.log('auqi', transactionLike.outputs[0].type)
-    //OutputType.Coin
-    /**
-     * tipos de output -> coin, contract
-     *  - coin: deolve um valor para um endereço
-     *  - contract: infos do contrato
-     *
-     *
-     */
 
-    const operations = transactionLike.outputs?.reduce(
-      (acc: IOutput[], output) => {
-        let operation;
-        if (output.type === OutputType.Coin) {
-          operation = {
-            assetId: output.assetId.toString(),
-            type: OutputType.Coin,
-            amount: bn(output.amount).format(),
-            to: {
-              address: output.to.toString(),
-              type: AddressType.account,
-            },
-            from: {
-              type: AddressType.account,
-              address: Address.fromString(from).toHexString(),
-            },
-            name: IFuelTransactionNames.TRANSFER_ASSET,
-            assetsSent: [
-              {
-                amount: bn(output.amount).format(),
-                assetId: output.assetId.toString(),
-              },
-            ],
-          };
-        } else if (output.type === OutputType.Contract) {
-          if (!transactionLike.inputs)
-            throw new Error('Invalid transaction inputs');
-          const isContract =
-            transactionLike.inputs[Number(output.inputIndex)].type ==
-            InputType.Contract;
-          if (!isContract) throw new Error('Invalid contract input');
-          const input = transactionLike.inputs[
-            Number(output.inputIndex)
-          ] as ContractTransactionRequestInput;
-          operation = {
-            calls: [],
-            assetId: NativeAssetId,
-            type: OutputType.Contract,
-            amount: '0.00',
-            to: {
-              address: input.contractId.toString(),
-              type: AddressType.contract,
-            },
-            from: {
-              type: AddressType.account,
-              address: Address.fromString(from).toHexString(),
-            },
-            name: IFuelTransactionNames.CONTRACT_CALL,
-          };
-        }
-        if (operation) acc.push(operation);
-        return acc;
-      },
-      [],
+    const auth = authCredentials();
+    const vault = await Vault.create({
+      predicateAddress: from,
+      token: auth.token,
+      address: auth.address,
+    });
+
+    let transactionRequest = ScriptTransactionRequest.from(transactionLike);
+    transactionRequest = await BaseTransfer.prepareTransaction(
+      vault,
+      transactionRequest,
     );
 
+    const { operations } = await getTransactionSummaryFromRequest({
+      transactionRequest,
+      provider,
+    });
+
     return {
-      fee: fee.maxFee.format(),
+      fee: transactionRequest.maxFee.format(),
       operations: operations,
     };
   }

--- a/src/modules/transactions/components/TransactionCard/Amount.tsx
+++ b/src/modules/transactions/components/TransactionCard/Amount.tsx
@@ -6,32 +6,37 @@ import {
   Text,
   useMediaQuery,
 } from '@chakra-ui/react';
-
 import { ITransferAsset } from 'bakosafe';
 import { bn } from 'fuels';
 
-import { assetsMap } from '@/modules/core';
 import bakoIcon from '@/assets/tokens/bako.svg';
-import { useTxAmountToUSD } from '@/modules/assets-tokens/hooks/useTxAmountToUSD';
 import { CustomSkeleton } from '@/components';
+import { useTxAmountToUSD } from '@/modules/assets-tokens/hooks/useTxAmountToUSD';
+import { assetsMap } from '@/modules/core';
 import { useWorkspaceContext } from '@/modules/workspace/WorkspaceProvider';
 
+import { useGetAssetsByOperations } from '../../hooks';
+import { TransactionWithVault } from '../../services';
 interface TransactionCardAmountProps {
-  assets: ITransferAsset[];
+  transaction: TransactionWithVault;
+  isDeposit: boolean;
 }
 
-const Amount = ({ assets }: TransactionCardAmountProps) => {
+const Amount = ({ transaction, isDeposit }: TransactionCardAmountProps) => {
+  const { operationAssets, hasNoDefaultAssets } =
+    useGetAssetsByOperations(transaction);
+
   const [showOnlyOneAsset] = useMediaQuery('(max-width: 400px)');
   const {
     tokensUSD,
     screenSizes: { isMobile, isExtraSmall },
   } = useWorkspaceContext();
 
-  const totalAmoutSent = assets
+  const totalAmoutSent = transaction.assets
     .reduce((total, asset) => total.add(bn.parseUnits(asset.amount)), bn(0))
     .format();
 
-  const oneAssetOfEach = assets.reduce((uniqueAssets, current) => {
+  const oneAssetOfEach = transaction.assets.reduce((uniqueAssets, current) => {
     if (!uniqueAssets.find((asset) => asset.assetId === current.assetId)) {
       uniqueAssets.push(current);
     }
@@ -42,9 +47,9 @@ const Amount = ({ assets }: TransactionCardAmountProps) => {
   const isMultiToken = oneAssetOfEach.length >= 2;
 
   const txUSDAmount = useTxAmountToUSD(
-    assets,
+    hasNoDefaultAssets && isDeposit ? [operationAssets] : transaction.assets,
     tokensUSD?.isLoading,
-    tokensUSD?.data!,
+    tokensUSD?.data,
   );
 
   return (
@@ -59,8 +64,9 @@ const Amount = ({ assets }: TransactionCardAmountProps) => {
         justifyContent={isMobile ? 'start' : 'end'}
         position="relative"
       >
-        {oneAssetOfEach.map((asset) => (
+        {oneAssetOfEach.map((asset, index) => (
           <Avatar
+            key={index}
             name={assetsMap[asset.assetId]?.slug ?? 'UKN'}
             src={assetsMap[asset.assetId]?.icon ?? bakoIcon}
             ignoreFallback
@@ -81,7 +87,9 @@ const Amount = ({ assets }: TransactionCardAmountProps) => {
           </Text>
         ) : (
           <Text color="grey.75" fontSize="sm">
-            {totalAmoutSent}
+            {hasNoDefaultAssets && isDeposit
+              ? operationAssets.amount
+              : totalAmoutSent}
           </Text>
         )}
         <Text

--- a/src/modules/transactions/components/TransactionCard/Container.tsx
+++ b/src/modules/transactions/components/TransactionCard/Container.tsx
@@ -16,13 +16,13 @@ import { Card, DownLeftArrowGreen, UpRightArrowYellow } from '@/components';
 import { ContractIcon } from '@/components/icons/tx-contract';
 import { DeployIcon } from '@/components/icons/tx-deploy';
 import { TransactionState } from '@/modules/core';
+import { useWorkspaceContext } from '@/modules/workspace/WorkspaceProvider';
 
 import { TransactionCard, transactionStatus } from '../..';
 import { useDetailsDialog } from '../../hooks/details';
+import { useVerifyTransactionInformations } from '../../hooks/details/useVerifyTransactionInformations';
 import { TransactionWithVault } from '../../services/types';
 import { DetailsDialog } from './DetailsDialog';
-import { useVerifyTransactionInformations } from '../../hooks/details/useVerifyTransactionInformations';
-import { useWorkspaceContext } from '@/modules/workspace/WorkspaceProvider';
 
 interface TransactionCardContainerProps extends CardProps {
   status: TransactionState;
@@ -139,7 +139,10 @@ const Container = ({
                 />
               )}
 
-              <TransactionCard.Amount assets={transaction.assets} />
+              <TransactionCard.Amount
+                transaction={transaction}
+                isDeposit={isDeposit}
+              />
               <TransactionCard.Status
                 transaction={transaction}
                 status={transactionStatus({

--- a/src/modules/transactions/components/TransactionCard/DetailsDialog.tsx
+++ b/src/modules/transactions/components/TransactionCard/DetailsDialog.tsx
@@ -5,14 +5,15 @@ import {
   HStack,
   VStack,
 } from '@chakra-ui/react';
+import { TransactionType } from 'bakosafe';
 import format from 'date-fns/format';
 
 import { Dialog, DialogModalProps } from '@/components';
 import { TransactionState } from '@/modules/core/models/transaction';
 import { TransactionCard, transactionStatus } from '@/modules/transactions';
 
-import { TransactionWithVault } from '../../services/types';
 import { useTransactionsContext } from '../../providers/TransactionsProvider';
+import { TransactionWithVault } from '../../services/types';
 
 interface DetailsDialogProps extends Omit<DialogModalProps, 'children'> {
   transaction: TransactionWithVault;
@@ -54,7 +55,10 @@ const DetailsDialog = ({ ...props }: DetailsDialogProps) => {
         <VStack spacing={{ base: 3, xs: 5 }} display="block">
           <VStack w="full" spacing={3}>
             <HStack w="full">
-              <TransactionCard.Amount assets={transaction.assets} />
+              <TransactionCard.Amount
+                transaction={transaction}
+                isDeposit={transaction?.type === TransactionType.DEPOSIT}
+              />
 
               <TransactionCard.CreationDate>
                 {format(new Date(transaction?.createdAt), 'EEE, dd MMM')}

--- a/src/modules/transactions/components/TransactionCard/deposit-details/DepositDetails.tsx
+++ b/src/modules/transactions/components/TransactionCard/deposit-details/DepositDetails.tsx
@@ -1,19 +1,35 @@
 import { Box, Button, Icon, Text, VStack } from '@chakra-ui/react';
-
-import DetailItem from './DetailItem';
 import { css } from '@emotion/react';
 import { TransactionStatus } from 'bakosafe';
-import { shakeAnimationY } from '@/modules/core';
-import { TransactionWithVault } from '../../../services';
+import { bn } from 'fuels';
+
 import { UpRightArrow } from '@/components';
+import { shakeAnimationY } from '@/modules/core';
 import { useWorkspaceContext } from '@/modules/workspace/WorkspaceProvider';
+
+import { TransactionWithVault } from '../../../services';
+import DetailItem from './DetailItem';
 
 type DepositDetailsProps = {
   transaction: TransactionWithVault;
 };
 
 const DepositDetails = ({ transaction }: DepositDetailsProps) => {
-  const sentBy = transaction.txData.inputs[0]['owner'];
+  const correctTransactionInput = transaction.txData.inputs.filter(
+    (input) => input.type === 0,
+  )[0];
+
+  const hasNoAssets = !transaction.assets.length;
+
+  const amountFromInput = hasNoAssets
+    ? {
+        amount: bn(correctTransactionInput['amount']).format(),
+        assetId: correctTransactionInput['assetId'],
+        to: transaction.predicate?.predicateAddress,
+      }
+    : null;
+
+  const sentBy = correctTransactionInput['owner'];
 
   const handleViewInExplorer = async () => {
     const { hash } = transaction;
@@ -44,6 +60,9 @@ const DepositDetails = ({ transaction }: DepositDetailsProps) => {
         </Box>
 
         <Box alignItems="flex-start" flexWrap="wrap" w="full">
+          {hasNoAssets && amountFromInput && (
+            <DetailItem asset={amountFromInput} sentBy={sentBy} />
+          )}
           {transaction.assets.map((asset, index) => (
             <DetailItem
               key={index}

--- a/src/modules/transactions/components/TransactionCard/deposit-details/DepositDetails.tsx
+++ b/src/modules/transactions/components/TransactionCard/deposit-details/DepositDetails.tsx
@@ -1,10 +1,10 @@
 import { Box, Button, Icon, Text, VStack } from '@chakra-ui/react';
 import { css } from '@emotion/react';
 import { TransactionStatus } from 'bakosafe';
-import { bn } from 'fuels';
 
 import { UpRightArrow } from '@/components';
 import { shakeAnimationY } from '@/modules/core';
+import { useGetAssetsByOperations } from '@/modules/transactions/hooks';
 import { useWorkspaceContext } from '@/modules/workspace/WorkspaceProvider';
 
 import { TransactionWithVault } from '../../../services';
@@ -15,28 +15,8 @@ type DepositDetailsProps = {
 };
 
 const DepositDetails = ({ transaction }: DepositDetailsProps) => {
-  const correctTransactionInput = transaction.txData.inputs.filter(
-    (input) => input.type === 0,
-  )[0];
-
-  // const sentBy = transaction.txData.inputs[0]['owner'];
-
-  const hasNoAssets = !transaction.assets.length;
-
-  const test = transaction.txData.outputs.filter(
-    (output) => output.type === 3,
-  )[0];
-
-  const amountFromInput = hasNoAssets
-    ? {
-        amount: bn(correctTransactionInput['amount']).format(),
-        // assetId: correctTransactionInput['assetId'],
-        assetId: test['assetId'],
-        to: transaction.predicate?.predicateAddress, //this logic is also wrong
-      }
-    : null;
-
-  const sentBy = correctTransactionInput['owner'];
+  const { operationAssets, sentBy, hasNoDefaultAssets } =
+    useGetAssetsByOperations(transaction);
 
   const handleViewInExplorer = async () => {
     const { hash } = transaction;
@@ -45,8 +25,6 @@ const DepositDetails = ({ transaction }: DepositDetailsProps) => {
       '_BLANK',
     );
   };
-
-  console.log('trasnction', transaction);
 
   const {
     screenSizes: { isMobile },
@@ -69,8 +47,8 @@ const DepositDetails = ({ transaction }: DepositDetailsProps) => {
         </Box>
 
         <Box alignItems="flex-start" flexWrap="wrap" w="full">
-          {hasNoAssets && test && (
-            <DetailItem asset={amountFromInput} sentBy={sentBy} />
+          {hasNoDefaultAssets && operationAssets && (
+            <DetailItem asset={operationAssets} sentBy={sentBy} />
           )}
           {transaction.assets.map((asset, index) => (
             <DetailItem

--- a/src/modules/transactions/components/TransactionCard/deposit-details/DepositDetails.tsx
+++ b/src/modules/transactions/components/TransactionCard/deposit-details/DepositDetails.tsx
@@ -19,13 +19,20 @@ const DepositDetails = ({ transaction }: DepositDetailsProps) => {
     (input) => input.type === 0,
   )[0];
 
+  // const sentBy = transaction.txData.inputs[0]['owner'];
+
   const hasNoAssets = !transaction.assets.length;
+
+  const test = transaction.txData.outputs.filter(
+    (output) => output.type === 3,
+  )[0];
 
   const amountFromInput = hasNoAssets
     ? {
         amount: bn(correctTransactionInput['amount']).format(),
-        assetId: correctTransactionInput['assetId'],
-        to: transaction.predicate?.predicateAddress,
+        // assetId: correctTransactionInput['assetId'],
+        assetId: test['assetId'],
+        to: transaction.predicate?.predicateAddress, //this logic is also wrong
       }
     : null;
 
@@ -38,6 +45,8 @@ const DepositDetails = ({ transaction }: DepositDetailsProps) => {
       '_BLANK',
     );
   };
+
+  console.log('trasnction', transaction);
 
   const {
     screenSizes: { isMobile },
@@ -60,7 +69,7 @@ const DepositDetails = ({ transaction }: DepositDetailsProps) => {
         </Box>
 
         <Box alignItems="flex-start" flexWrap="wrap" w="full">
-          {hasNoAssets && amountFromInput && (
+          {hasNoAssets && test && (
             <DetailItem asset={amountFromInput} sentBy={sentBy} />
           )}
           {transaction.assets.map((asset, index) => (

--- a/src/modules/transactions/components/TransactionCard/deposit-details/DetailItem.tsx
+++ b/src/modules/transactions/components/TransactionCard/deposit-details/DetailItem.tsx
@@ -21,7 +21,7 @@ import TokenInfos from './TokenInfos';
 
 interface DetailItemProps {
   asset: ITransferAsset;
-  index: number;
+  index?: number;
   sentBy: string;
 }
 

--- a/src/modules/transactions/components/TransactionCard/deposit-details/DetailItem.tsx
+++ b/src/modules/transactions/components/TransactionCard/deposit-details/DetailItem.tsx
@@ -34,7 +34,7 @@ const DetailItem = ({ asset, index, sentBy }: DetailItemProps) => {
   const txUSDAmount = useTxAmountToUSD(
     [asset],
     tokensUSD?.isLoading,
-    tokensUSD?.data!,
+    tokensUSD?.data,
   );
 
   const isFirstItem = index === 0;

--- a/src/modules/transactions/components/transactionCardMobile/index.tsx
+++ b/src/modules/transactions/components/transactionCardMobile/index.tsx
@@ -13,11 +13,11 @@ import { ContractIcon } from '@/components/icons/tx-contract';
 import { DeployIcon } from '@/components/icons/tx-deploy';
 
 import { useDetailsDialog } from '../../hooks/details';
+import { useVerifyTransactionInformations } from '../../hooks/details/useVerifyTransactionInformations';
 import { TransactionWithVault } from '../../services/types';
 import { transactionStatus } from '../../utils';
 import { TransactionCard } from '../TransactionCard';
 import { DetailsDialog } from '../TransactionCard/DetailsDialog';
-import { useVerifyTransactionInformations } from '../../hooks/details/useVerifyTransactionInformations';
 
 interface TransactionCardMobileProps extends CardProps {
   transaction: TransactionWithVault;
@@ -113,7 +113,10 @@ const TransactionCardMobile = (props: TransactionCardMobileProps) => {
             <Divider borderColor="grey.950" />
 
             <HStack justifyContent="space-between" w="full">
-              <TransactionCard.Amount assets={transaction.assets} />
+              <TransactionCard.Amount
+                transaction={transaction}
+                isDeposit={isDeposit}
+              />
 
               <TransactionCard.ActionsMobile awaitingAnswer={awaitingAnswer} />
             </HStack>

--- a/src/modules/transactions/hooks/index.ts
+++ b/src/modules/transactions/hooks/index.ts
@@ -2,3 +2,4 @@ export * from './create';
 export * from './details';
 export * from './list';
 export * from './list/useUserTransactionsRequest';
+export * from './useGetAssetsByOperations';

--- a/src/modules/transactions/hooks/useGetAssetsByOperations.ts
+++ b/src/modules/transactions/hooks/useGetAssetsByOperations.ts
@@ -1,0 +1,46 @@
+import { ITransferAsset } from 'bakosafe';
+import { bn } from 'fuels';
+
+import { TransactionWithVault } from '../services';
+
+interface UseGetAssetsByOperationsResult {
+  operationAssets: ITransferAsset;
+  sentBy: string;
+  hasNoDefaultAssets: boolean;
+}
+
+const useGetAssetsByOperations = (
+  transaction: TransactionWithVault,
+): UseGetAssetsByOperationsResult => {
+  const hasNoDefaultAssets = !transaction?.assets?.length;
+
+  if (!transaction?.summary?.operations?.length) {
+    return {
+      operationAssets: { amount: '', assetId: '', to: '' },
+      sentBy: '',
+      hasNoDefaultAssets,
+    };
+  }
+
+  // this [firstOperation] it's the same as const firstOperation = transaction.summary?.operations[0]
+  const {
+    operations: [firstOperation],
+  } = transaction.summary;
+  const { assetsSent = [], to, from } = firstOperation;
+
+  const operationAssets = {
+    amount: bn(assetsSent[0]?.amount ?? '').format() ?? '',
+    assetId: assetsSent[0]?.assetId ?? '',
+    to: to?.address ?? '',
+  };
+
+  const sentBy = from?.address ?? '';
+
+  return {
+    operationAssets,
+    sentBy,
+    hasNoDefaultAssets,
+  };
+};
+
+export { useGetAssetsByOperations };


### PR DESCRIPTION
https://app.clickup.com/t/86a4r7bbx

This pr depends on: https://github.com/infinitybase/bako-safe-api/pull/217 that's already approved.

Deposits specific from contract call doesn't has the `assets` array field and the field where we get the `owner` or who sent the tokens is different. So, we need to get those informations from `operations` field.

