### PR TITLE
FIX: Duplicated axios setup call and improve logic to logout user when receive a 404

### DIFF
--- a/src/modules/transactions/components/TransactionCard/DetailsTransactionStepper.tsx
+++ b/src/modules/transactions/components/TransactionCard/DetailsTransactionStepper.tsx
@@ -6,7 +6,7 @@ interface DetailsTransactionStepperProps {
   predicateId: string;
   children: (
     isLoading: boolean,
-    transactionHistory: ITransactionHistory[] | null,
+    transactionHistory: ITransactionHistory[] | undefined,
   ) => React.ReactNode;
 }
 

--- a/src/modules/transactions/hooks/details/useTransactionHistory.ts
+++ b/src/modules/transactions/hooks/details/useTransactionHistory.ts
@@ -1,31 +1,18 @@
-import { useEffect, useState } from 'react';
-
-import { ITransactionHistory } from '../../services';
 import { useTransactionHistoryRequest } from './useTransactionHistoryRequest';
 
 export const useTransactionHistory = (
   transactionId: string,
   predicateId: string,
 ) => {
-  const [transactionHistory, setTransactionHistory] = useState<
-    ITransactionHistory[] | null
-  >(null);
-
   const transactionHistoryRequest = useTransactionHistoryRequest(
     transactionId,
     predicateId,
   );
 
-  useEffect(() => {
-    if (transactionHistoryRequest.data) {
-      setTransactionHistory(
-        transactionHistoryRequest.data.map((transaction) => transaction),
-      );
-    }
-  }, [transactionHistoryRequest.data, transactionId]);
-
   return {
     ...transactionHistoryRequest,
-    transactionHistory,
+    transactionHistory: transactionHistoryRequest?.data?.map(
+      (transaction) => transaction,
+    ),
   };
 };

--- a/src/modules/workspace/hooks/details/useWorkspaceDetails.ts
+++ b/src/modules/workspace/hooks/details/useWorkspaceDetails.ts
@@ -34,14 +34,16 @@ const useWorkspaceDetails = () => {
   const {
     isLoading: isGifAnimationLoading,
     refetch: invalidateGifAnimationRequest,
-  } = useGifLoadingRequest(
-    authDetails.handlers.logout,
-    authDetails.userInfos,
-    isTokenExpired,
-    setIsTokenExpired,
-  );
+  } = useGifLoadingRequest();
 
-  setupAxiosInterceptors();
+  useEffect(() => {
+    setupAxiosInterceptors(
+      isTokenExpired,
+      setIsTokenExpired,
+      authDetails.handlers.logout,
+    );
+  }, []);
+
   const {
     handlers: { hasPermission, ...handlersData },
     requests: { workspaceBalance, latestPredicates, ...requestsData },
@@ -75,10 +77,6 @@ const useWorkspaceDetails = () => {
     isWorkspaceBalanceLoading: workspaceBalance.isLoading,
     isTokenExpired,
   });
-
-  useEffect(() => {
-    setupAxiosInterceptors();
-  }, []);
 
   return {
     isWorkspaceReady,

--- a/src/modules/workspace/hooks/useGifLoadingRequest.ts
+++ b/src/modules/workspace/hooks/useGifLoadingRequest.ts
@@ -1,38 +1,15 @@
 import { useQuery } from '@tanstack/react-query';
 
-import { authCredentials } from '@/modules';
-import { IUserInfos } from '@/modules/auth/services';
-
 export enum GifLoadingRequestQueryKey {
   ANIMATION_LOADING = 'animation-loading',
 }
 
-const useGifLoadingRequest = (
-  logout?: () => void,
-  userInfos?: IUserInfos,
-  isTokenExpired?: boolean,
-  setIsTokenExpired?: (isTokenExpired: boolean) => void,
-) => {
-  const { address, token } = authCredentials();
-
+const useGifLoadingRequest = () => {
   const { isLoading, isFetching, refetch } = useQuery({
     queryKey: [GifLoadingRequestQueryKey.ANIMATION_LOADING],
     queryFn: () =>
       new Promise((resolve) => {
-        if (
-          !token &&
-          !address &&
-          !userInfos?.address &&
-          !isLoading &&
-          !isFetching
-        ) {
-          setIsTokenExpired?.(true);
-        }
         setTimeout(() => {
-          if (isTokenExpired) {
-            setIsTokenExpired?.(false);
-            logout?.();
-          }
           resolve(true);
         }, 2880);
       }),


### PR DESCRIPTION

When i merged the this branch: https://github.com/infinitybase/bako-safe-ui/pull/356 with this one: https://github.com/infinitybase/bako-safe-ui/pull/381
 
the axios setup was being called twice in the `useWorkspaceDetails` and it caused a bug: when the user loged in and try to do some action, he was kicked out from the application. 

Instead of only removing one import, i decide to improve the logic to a more accurrated one.