### PR TITLE
FIX: Vault tx list updating while signin a tx

### DIFF
--- a/src/modules/vault/pages/details/index.tsx
+++ b/src/modules/vault/pages/details/index.tsx
@@ -48,7 +48,7 @@ const VaultDetailsPage = () => {
     vaultTransactions: {
       filter: { txFilterType },
       lists: { limitedTransactions },
-      request: { isLoading, isFetching },
+      request: { isLoading },
       handlers: { handleIncomingAction, handleOutgoingAction },
     },
     pendingSignerTransactions,
@@ -251,7 +251,7 @@ const VaultDetailsPage = () => {
 
       <CustomSkeleton
         minH="30vh"
-        isLoaded={!vault.isLoading && !isLoading && !isFetching}
+        isLoaded={!vault.isLoading && !isLoading}
         h={!vault.isLoading && !isLoading ? 'unset' : '100px'}
       >
         {hasTransactions


### PR DESCRIPTION
https://app.clickup.com/t/86a4w85bn

- This error happens due the `isFetching` conditional on the skeleton. 
It was put there to shown the skeleton when the vault receives a deposit: https://github.com/infinitybase/bako-safe-ui/pull/374 Just removing it is the faster way to solve the problem.