### PR TITLE
fix(connector): not redirect user to login if token expired into transaction page

### DIFF
--- a/src/modules/auth/hooks/useAuthUrlParams.ts
+++ b/src/modules/auth/hooks/useAuthUrlParams.ts
@@ -12,7 +12,7 @@ const useAuthUrlParams = () => {
 
   const isTxFromDapp = useMemo(
     () =>
-      !sessionId &&
+      !!sessionId &&
       pathname.includes('dapp') &&
       pathname.includes('transaction'),
     [pathname, sessionId],


### PR DESCRIPTION
- Does not redirect user to login if token has expired and tries to access transaction page