### PR TITLE
FIX: Auth - Prevent Unauthorized user auth request

### DIFF
--- a/src/modules/workspace/hooks/details/useWorkspaceDetails.ts
+++ b/src/modules/workspace/hooks/details/useWorkspaceDetails.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useMemo, useState } from 'react';
 
 import { queryClient, setupAxiosInterceptors } from '@/config';
 import {
@@ -45,7 +45,7 @@ const useWorkspaceDetails = () => {
     refetch: invalidateGifAnimationRequest,
   } = useGifLoadingRequest();
 
-  useEffect(() => {
+  useMemo(() => {
     setupAxiosInterceptors({
       isTxFromDapp,
       isTokenExpired,
@@ -131,6 +131,9 @@ const useWorkspaceDetails = () => {
     invalidateGifAnimationRequest,
     screenSizes,
     resetHomeRequests,
+    isTxFromDapp,
+    isTokenExpired,
+    setIsTokenExpired,
   };
 };
 


### PR DESCRIPTION
There's no task on clickup for this problem;

### Explanation

Whenever a user refreshed the page, a request to `/user/latest/info` was returning a 401. This problem was because how `useEffect` works. The `useEffect` was executing the request before the api setup is completed built.

With this problem, even our axios api setup couldn't get the error and that's why the user wasn't being logged out after receiving a 401. 



