### PR TITLE
CHORE: Min Signers select shows options above when has two or more addresses

### DIFF
--- a/src/modules/vault/components/CreateVaultWarning.tsx
+++ b/src/modules/vault/components/CreateVaultWarning.tsx
@@ -9,9 +9,12 @@ import {
 
 import { TriangleWarning } from '@/components';
 
-interface ICreateVaultWarningProps extends StackProps {}
+interface ICreateVaultWarningProps extends StackProps {
+  message: string;
+}
 
 const CreateVaultWarning = (props: ICreateVaultWarningProps) => {
+  const { message, ...rest } = props;
   return (
     <VStack
       w="full"
@@ -21,7 +24,7 @@ const CreateVaultWarning = (props: ICreateVaultWarningProps) => {
       backdropFilter=" blur(30px)"
       padding="8px 8px 12px 8px"
       alignItems="start"
-      {...props}
+      {...rest}
     >
       <HStack>
         <Icon as={TriangleWarning} fontSize="md" />
@@ -42,9 +45,7 @@ const CreateVaultWarning = (props: ICreateVaultWarningProps) => {
         color="brand.400"
         pl={7}
       >
-        Please ensure that all signer addresses are valid and accessible wallet
-        addresses on the Fuel Network. Addresses from other Bako Safe Vaults and
-        wallets from other networks cannot be used as signers.
+        {message}
       </Text>
     </VStack>
   );

--- a/src/modules/vault/components/dialog/create/form/steps/addresses.tsx
+++ b/src/modules/vault/components/dialog/create/form/steps/addresses.tsx
@@ -52,8 +52,8 @@ const VaultAddressesStep = (props: VaultAddressesStepProps) => {
     },
   } = useWorkspaceContext();
 
-  const hasThreeOrMoreAddress =
-    form.watch('addresses') && form.watch('addresses')!.length >= 3;
+  const hasTwoOrMoreAddresses =
+    form.watch('addresses') && form.watch('addresses')!.length >= 2;
 
   const [isFirstLoad, setIsFirstLoad] = useState(true);
   const [currentInputIndex, setCurrentInputIndex] = useState<
@@ -303,7 +303,7 @@ const VaultAddressesStep = (props: VaultAddressesStepProps) => {
               render={({ field }) => (
                 <FormControl position="relative" maxW={'full'} w="24">
                   <Select
-                    needShowOptionsAbove={hasThreeOrMoreAddress}
+                    needShowOptionsAbove={hasTwoOrMoreAddresses}
                     style={{
                       background: '#201F1D',
                     }}

--- a/src/modules/vault/components/dialog/create/form/steps/addresses.tsx
+++ b/src/modules/vault/components/dialog/create/form/steps/addresses.tsx
@@ -120,7 +120,12 @@ const VaultAddressesStep = (props: VaultAddressesStepProps) => {
           }}
           h={{ base: '60vh', xs: 500 }}
         >
-          <CreateVaultWarning mb={2} />
+          <CreateVaultWarning
+            mb={2}
+            message="Please ensure that all signer addresses are valid and accessible wallet
+        addresses on the Fuel Network. Addresses from other Bako Safe Vaults and
+        wallets from other networks cannot be used as signers."
+          />
 
           <Dialog.Section
             w="full"

--- a/src/modules/vault/components/dialog/create/index.tsx
+++ b/src/modules/vault/components/dialog/create/index.tsx
@@ -121,7 +121,12 @@ Bako Safe leverages Fuel predicates to manage vault permissions off-chain. There
               </Text>
             </HStack>
           )}
-          {tabs.tab === 2 && <CreateVaultWarning mb={4} />}
+          {tabs.tab === 2 && (
+            <CreateVaultWarning
+              mb={4}
+              message="Before initiating high-value deposits, first conduct smaller deposits and transactions to confirm that all signers have access to their wallets and that the vault’s funds can be transferred securely."
+            />
+          )}
           <HStack w="full" justifyContent="space-between">
             <Dialog.SecondaryAction
               bgColor="transparent"


### PR DESCRIPTION
There's no task on click up for this. It's a fix that's Vini asked for on discord to complement this pr: https://github.com/infinitybase/bako-safe-ui/pull/516

Previous, the options only was shown above when we had 3 or more adddresses and now this behavior happens when we have 2 or more

![image](https://github.com/user-attachments/assets/64061167-ca30-4177-a8ce-a1d2c7b15ef9)
