### PR TITLE
FIX: Black screen due address formating

### DIFF
--- a/src/components/addressWithCopyButton/index.tsx
+++ b/src/components/addressWithCopyButton/index.tsx
@@ -36,7 +36,7 @@ const AddressWithCopyBtn = ({
     },
   } = useWorkspaceContext();
 
-  const b256Address = Address.fromString(address ?? '').toB256();
+  const b256Address = address ? Address.fromString(address).toB256() : '';
 
   return (
     <Flex
@@ -95,7 +95,7 @@ const AddressWithCopyBtn = ({
         size="xs"
         minW={2}
         aria-label="Copy"
-        addressToCopy={Address.fromString(address ?? '').toB256()}
+        addressToCopy={address && Address.fromString(address).toB256()}
       />
     </Flex>
   );

--- a/src/layouts/dashboard/header.tsx
+++ b/src/layouts/dashboard/header.tsx
@@ -16,7 +16,7 @@ import {
   VStack,
 } from '@chakra-ui/react';
 import { useFuel } from '@fuels/react';
-import { Address, ZeroBytes32 } from 'fuels';
+import { Address } from 'fuels';
 import { useEffect } from 'react';
 import { FaChevronDown } from 'react-icons/fa';
 
@@ -127,9 +127,9 @@ const UserBox = () => {
     setUnreadCounter(unreadCounter);
   }, []);
 
-  const b256UserAddress = Address.fromString(
-    authDetails.userInfos?.address ?? ZeroBytes32,
-  ).toB256();
+  const b256UserAddress =
+    authDetails.userInfos?.address &&
+    Address.fromString(authDetails.userInfos?.address).toB256();
 
   return (
     <>


### PR DESCRIPTION
https://app.clickup.com/t/86a59ga8v

The problem was because we was trying to use the `Address` from fuels to format the user address from the cookies. But, when you disconnect in the connector, the cookies are cleared. So i just add a new validation to only format the address if it exists. 

To reproduce the error, you don't need to do the steps shown in the task. Just loggin on bako and then go to Application in your brower and clear the cookies, click in another tab on your brower and then come back to bako safe.