### PR TITLE
Fix/wrong asset and amount showed on transaction card

### DIFF
--- a/src/modules/transactions/components/TransactionCard/Amount.tsx
+++ b/src/modules/transactions/components/TransactionCard/Amount.tsx
@@ -16,6 +16,8 @@ import { useWorkspaceContext } from '@/modules/workspace/WorkspaceProvider';
 
 import { useGetAssetsByOperations } from '../../hooks';
 import { TransactionWithVault } from '../../services';
+import { AmountUSD } from './transfer-details';
+
 interface TransactionCardAmountProps extends BoxProps {
   transaction: TransactionWithVault;
   showAmount: boolean;
@@ -124,8 +126,7 @@ const Amount = ({
               color={isMultiToken ? ' grey.75' : 'grey.425'}
             >
               <CustomSkeleton isLoaded={!tokensUSD?.isLoading}>
-                {!!Number(txUSDAmount) && '$'}
-                {txUSDAmount}
+                <AmountUSD amount={txUSDAmount} />
               </CustomSkeleton>
             </Text>
           </Flex>

--- a/src/modules/transactions/components/TransactionCard/AssetBoxInfo.tsx
+++ b/src/modules/transactions/components/TransactionCard/AssetBoxInfo.tsx
@@ -106,7 +106,8 @@ const AssetBoxInfo = ({
           fontSize="xs"
           color="grey.500"
         >
-          {assetInfo.slug === 'UNK' ? '--' : `$${txUSDAmount}`}
+          {!!Number(txUSDAmount) && '$'}
+          {txUSDAmount}
         </Text>
       </VStack>
 

--- a/src/modules/transactions/components/TransactionCard/AssetBoxInfo.tsx
+++ b/src/modules/transactions/components/TransactionCard/AssetBoxInfo.tsx
@@ -17,6 +17,8 @@ import { useTxAmountToUSD } from '@/modules/assets-tokens/hooks/useTxAmountToUSD
 import { AssetModel } from '@/modules/core';
 import { useWorkspaceContext } from '@/modules/workspace/WorkspaceProvider';
 
+import { AmountUSD } from './transfer-details';
+
 interface AssetBoxInfoProps extends StackProps {
   asset?: AssetModel;
   isDeposit?: boolean;
@@ -106,8 +108,7 @@ const AssetBoxInfo = ({
           fontSize="xs"
           color="grey.500"
         >
-          {!!Number(txUSDAmount) && '$'}
-          {txUSDAmount}
+          <AmountUSD amount={txUSDAmount} />
         </Text>
       </VStack>
 

--- a/src/modules/transactions/components/TransactionCard/deposit-details/AmountsInfo.tsx
+++ b/src/modules/transactions/components/TransactionCard/deposit-details/AmountsInfo.tsx
@@ -3,6 +3,8 @@ import { Text, VStack } from '@chakra-ui/react';
 import { AssetModel } from '@/modules/core';
 import { useWorkspaceContext } from '@/modules/workspace/WorkspaceProvider';
 
+import { AmountUSD } from '../transfer-details';
+
 interface AmountsInfoProps {
   asset: AssetModel;
   txUSDAmount: string;
@@ -29,7 +31,7 @@ const AmountsInfo = ({ asset, txUSDAmount }: AmountsInfoProps) => {
         fontSize="xs"
         color="grey.500"
       >
-        ${txUSDAmount}
+        <AmountUSD amount={txUSDAmount} />
       </Text>
     </VStack>
   );

--- a/src/modules/transactions/components/TransactionCard/transfer-details/AmountUSD.tsx
+++ b/src/modules/transactions/components/TransactionCard/transfer-details/AmountUSD.tsx
@@ -1,0 +1,16 @@
+import { isNumericString } from '@/utils/is-numeric-string';
+
+interface AmountUSDProps {
+  amount: string;
+}
+
+const AmountUSD = ({ amount }: AmountUSDProps) => {
+  return (
+    <>
+      {isNumericString(amount) && '$'}
+      {amount}
+    </>
+  );
+};
+
+export { AmountUSD };

--- a/src/modules/transactions/components/TransactionCard/transfer-details/index.tsx
+++ b/src/modules/transactions/components/TransactionCard/transfer-details/index.tsx
@@ -1,1 +1,2 @@
+export * from './AmountUSD';
 export * from './TransactionBreakdown';

--- a/src/modules/transactions/hooks/useFormatSummaryAssets.ts
+++ b/src/modules/transactions/hooks/useFormatSummaryAssets.ts
@@ -37,9 +37,15 @@ const useFormatSummaryAssets = (
     };
   }
 
-  const _operations = predicateAddress
-    ? operations.filter((op) => op.to?.address === predicateAddress)
-    : operations;
+  const filterOperationsToVault = () => {
+    const operationsToVault = operations.filter(
+      (op) => op.assetsSent && op.to?.address === predicateAddress,
+    );
+
+    return operationsToVault.length ? operationsToVault : operations;
+  };
+
+  const _operations = predicateAddress ? filterOperationsToVault() : operations;
 
   const firstOperation = _operations[0] as OperationWithAssets;
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -3,6 +3,7 @@ export * from './current-path';
 export * from './format-asset-amount';
 export * from './gtm-custom-event';
 export * from './handle-action-using-keys';
+export * from './is-numeric-string';
 export * from './limit-characters';
 export * from './limit-name';
 export * from './verify-hex';

--- a/src/utils/is-numeric-string.ts
+++ b/src/utils/is-numeric-string.ts
@@ -1,0 +1,3 @@
+export const isNumericString = (value: string): boolean => {
+  return value.trim() !== '' && !isNaN(Number(value));
+};


### PR DESCRIPTION
- Shows correctly asset and amount on contract call transation card
- Shows amount if has asset value in USD
- Hides "$" if amount is not a numeric string


https://app.clickup.com/t/86a59x37y