### PR TITLE
fix(assets): get cached assets info

### DIFF
--- a/src/modules/core/utils/assets/data.ts
+++ b/src/modules/core/utils/assets/data.ts
@@ -68,21 +68,20 @@ export const formatedAssets = (chainId: number): Asset[] =>
 const assetsList: Asset[] = formatedAssets(getChainId());
 
 export const assetsMapFromFormattedFn = (tokenList: Assets = []): AssetMap => {
-  const assetsMap: AssetMap = assetsList.reduce(
-    (previousValue, currentValue) => {
-      return {
-        ...previousValue,
-        [currentValue.assetId]: {
-          name: currentValue?.name,
-          slug: currentValue?.slug,
-          icon: currentValue?.icon,
-          assetId: currentValue?.assetId,
-          units: currentValue?.units,
-        },
-      };
-    },
-    {},
-  );
+  const assets = formatedAssets(getChainId());
+
+  const assetsMap: AssetMap = assets.reduce((previousValue, currentValue) => {
+    return {
+      ...previousValue,
+      [currentValue.assetId]: {
+        name: currentValue?.name,
+        slug: currentValue?.slug,
+        icon: currentValue?.icon,
+        assetId: currentValue?.assetId,
+        units: currentValue?.units,
+      },
+    };
+  }, {});
 
   return assetsMap;
 };


### PR DESCRIPTION
## Description
This PR fixes the issue when listing asset information.

### Problem
- On the first access, the assets were not set in the local storage.
- The assetList was storing a static value, and only on the next reload would it have the correct value.

### Solution
- Do not use the static value from the assetList.
- Fetch the value directly from local storage.

### Issues
There may be performance issues because local storage is queried on every render. However, to improve performance, a refactor is needed so that the assets are set and consumed directly from the vault logic instead of the workspace logic.