### PR TITLE
Error when creating a transaction with many recipients.

### DIFF
--- a/src/modules/core/utils/address.ts
+++ b/src/modules/core/utils/address.ts
@@ -1,4 +1,4 @@
-import { AddressUtils as BakoAddressUtils } from 'bakosafe';
+import { AddressUtils as BakoAddressUtils, BakoProvider } from 'bakosafe';
 import { Address, isB256 } from 'fuels';
 
 export enum Batch32Prefix {
@@ -7,7 +7,7 @@ export enum Batch32Prefix {
 
 export type Batch32 = `${Batch32Prefix}.${string}`;
 
-class AddressUtils {
+export class AddressUtils {
   static isValid(address: string) {
     try {
       return BakoAddressUtils.isPasskey(address) || isB256(address);
@@ -39,4 +39,22 @@ class AddressUtils {
   }
 }
 
-export { AddressUtils };
+export class AddressValidator {
+  private addresses: Map<string, boolean>;
+
+  constructor(public provider: Promise<BakoProvider>) {
+    this.addresses = new Map();
+  }
+
+  async isValid(address: string) {
+    if (this.addresses.has(address)) {
+      return this.addresses.get(address)!;
+    }
+
+    const provider = await this.provider;
+    const isValid = await provider.isUserAccount(address);
+    this.addresses.set(address, isValid);
+
+    return isValid;
+  }
+}

--- a/src/modules/transactions/hooks/create/useCreateTransactionForm.ts
+++ b/src/modules/transactions/hooks/create/useCreateTransactionForm.ts
@@ -4,7 +4,12 @@ import { useMemo } from 'react';
 import { useFieldArray, useForm } from 'react-hook-form';
 import * as yup from 'yup';
 
-import { AddressUtils, AssetMap, NativeAssetId } from '@/modules/core/utils';
+import {
+  AddressUtils,
+  AddressValidator,
+  AssetMap,
+  NativeAssetId,
+} from '@/modules/core/utils';
 import { useWorkspaceContext } from '@/modules/workspace/WorkspaceProvider';
 
 export interface ITransactionField {
@@ -24,6 +29,12 @@ export type UseCreateTransactionFormParams = {
 
 const useCreateTransactionForm = (params: UseCreateTransactionFormParams) => {
   const { providerInstance, fuelsTokens } = useWorkspaceContext();
+
+  const addressValidator = useMemo(
+    () => new AddressValidator(providerInstance),
+    [providerInstance],
+  );
+
   const assetIdsAndAddresses = fuelsTokens?.flatMap((item) =>
     item.networks
       ?.map((network) => network['assetId'] ?? network['address'])
@@ -176,8 +187,7 @@ const useCreateTransactionForm = (params: UseCreateTransactionFormParams) => {
                 AddressUtils.isValid(address) && !isAssetIdOrAssetAddress;
               if (!isValid) return false;
 
-              const provider = await providerInstance;
-              return await provider.isUserAccount(address);
+              return addressValidator.isValid(address);
             } catch {
               return false;
             }


### PR DESCRIPTION
## Summary
When trying to create transactions with many recipients, an error occurred stating that the address could not receive assets. This happened because, whenever any information in the form was changed, all addresses would instantly execute `provider.isUserAccount(address)`, which caused the `Too many requests` error.

## Checklist
- [x] Create `` to cache in memory the result of addresses
- [x] Change the validator schema to implement the `AddressValidator`