### PR TITLE
Md/fix/reused consumed tokens

### DIFF
--- a/src/components/autocomplete/basic.tsx
+++ b/src/components/autocomplete/basic.tsx
@@ -77,7 +77,7 @@ const Autocomplete = ({
   inputRef,
   ...rest
 }: AutocompleteProps) => {
-  const [inputValue, setInputValue] = useState<string>('');
+  const [inputValue, setInputValue] = useState<string>(value ?? '');
   const [isFocused, setIsFocused] = useState<boolean>(false);
 
   const debounceTimeout = useRef<NodeJS.Timeout | null>(null);

--- a/src/components/input/amount.tsx
+++ b/src/components/input/amount.tsx
@@ -20,37 +20,44 @@ interface AmountInputProps extends InputProps {
   isInvalid?: boolean;
 }
 
-const AmountInput = (props: AmountInputProps) => (
-  <MaskedInput
-    mask={currencyMask}
-    value={props.value}
-    onChange={(event) => {
-      const inputValue = event.target.value;
+const AmountInput = (props: AmountInputProps) => {
+  const handleBlur = (event: React.FocusEvent<HTMLInputElement>) => {
+    let inputValue = event.target.value;
 
-      // Remove qualquer caractere não numérico, exceto ponto
-      event.target.value = inputValue.replace(/[^0-9.,]/g, '');
+    if (!inputValue.includes('.')) {
+      inputValue = `${inputValue}.00`;
+    }
 
-      // Lógica para atualizar o valor no estado do componente
-      props.onChange?.(event);
-    }}
-    render={(maskedInputRef, maskedInputProps) => (
-      <Input
-        {...props}
-        {...maskedInputProps}
-        autoComplete="off"
-        variant="dark"
-        color="gray"
-        step="any"
-        ref={(input) => maskedInputRef(input as HTMLInputElement)}
-        inputMode="decimal"
-        borderColor={props.isInvalid ? 'error' : undefined}
-        _focusVisible={{
-          borderColor: props.isInvalid ? 'error' : undefined,
-        }}
-        _hover={{}}
-      />
-    )}
-  />
-);
+    event.target.value = inputValue;
+
+    props.onChange?.(event);
+  };
+
+  return (
+    <MaskedInput
+      mask={currencyMask}
+      value={props.value}
+      onChange={props.onChange}
+      render={(maskedInputRef, maskedInputProps) => (
+        <Input
+          {...props}
+          {...maskedInputProps}
+          autoComplete="off"
+          variant="dark"
+          color="gray"
+          step="any"
+          ref={(input) => maskedInputRef(input as HTMLInputElement)}
+          inputMode="decimal"
+          borderColor={props.isInvalid ? 'error' : undefined}
+          _focusVisible={{
+            borderColor: props.isInvalid ? 'error' : undefined,
+          }}
+          _hover={{}}
+          onBlur={handleBlur}
+        />
+      )}
+    />
+  );
+};
 
 export { AmountInput };

--- a/src/components/input/amount.tsx
+++ b/src/components/input/amount.tsx
@@ -2,15 +2,16 @@ import { Input, InputProps } from '@chakra-ui/react';
 import MaskedInput from 'react-text-mask';
 import { createNumberMask } from 'text-mask-addons';
 
+// A máscara de número com separação de milhar e ponto decimal
 const currencyMask = createNumberMask({
   prefix: '',
   suffix: '',
   includeThousandsSeparator: true,
-  thousandsSeparatorSymbol: '',
+  thousandsSeparatorSymbol: ',', // Usando vírgula como separador de milhar
   allowDecimal: true,
   decimalSymbol: '.',
-  decimalLimit: 9, // how many digits allowed after the decimal
-  integerLimit: 9, // limit length of integer numbers
+  decimalLimit: 9, // Limita a 9 casas decimais
+  integerLimit: 9, // Limita o número de dígitos inteiros
   allowNegative: false,
   allowLeadingZeroes: false,
 });
@@ -25,49 +26,11 @@ const AmountInput = (props: AmountInputProps) => (
     value={props.value}
     onChange={(event) => {
       const inputValue = event.target.value;
-      const nativeEvent = event.nativeEvent as InputEvent;
-      const isComma = nativeEvent.data === ',';
 
-      // This if case just handle the comma (',') to replace it to a dot ('.')
-      if (isComma && !inputValue.endsWith('.')) {
-        const caretPosition = event.target.selectionStart ?? 0;
+      // Remove qualquer caractere não numérico, exceto ponto
+      event.target.value = inputValue.replace(/[^0-9.,]/g, '');
 
-        // Determine if the comma is the first character
-        const isFirstChar = inputValue.length === 0;
-        const complement = isFirstChar ? '0.' : '.';
-
-        // Build the new value by appending or replacing the comma with a dot
-        const newValue = isFirstChar
-          ? complement
-          : inputValue.slice(0, caretPosition) +
-            complement +
-            inputValue.slice(caretPosition);
-
-        // Update the input value with the new value containing the dot
-        event.target.value = newValue;
-
-        // Adjust the "focus" position after the dot is inserted
-        const newCaretPosition = caretPosition + (isFirstChar ? 2 : 1);
-        event.target.setSelectionRange(newCaretPosition, newCaretPosition);
-
-        props.onChange?.(event);
-        return;
-      }
-
-      const isBackspace = inputValue.length < (props.value as string).length;
-
-      if (
-        inputValue.startsWith('0') &&
-        inputValue.length === 1 &&
-        isBackspace
-      ) {
-        event.target.value = ``;
-      } else if (inputValue.startsWith('0') && inputValue.length === 1) {
-        event.target.value = `0.`;
-      }
-
-      event.target.value = event.target.value.replace(/[^0-9.]/g, '');
-
+      // Lógica para atualizar o valor no estado do componente
       props.onChange?.(event);
     }}
     render={(maskedInputRef, maskedInputProps) => (

--- a/src/modules/transactions/components/dialog/create/transactions.tsx
+++ b/src/modules/transactions/components/dialog/create/transactions.tsx
@@ -110,6 +110,7 @@ const TransactionFormField = (props: TransctionFormFieldProps) => {
     assets: assets.assets,
     nfts: assets.nfts,
     recipients: form.watch('transactions'),
+    getBalanceAvailable,
   });
 
   return (
@@ -246,7 +247,7 @@ const TransactionFormField = (props: TransctionFormFieldProps) => {
                 />
                 <FormLabel color="gray">Amount</FormLabel>
                 <FormHelperText>
-                  {asset && (
+                  {parseFloat(balanceAvailable) > 0 && asset && (
                     <Text display="flex" alignItems="center">
                       Balance (available):{' '}
                       {isFeeCalcLoading ? (

--- a/src/modules/transactions/hooks/assets/useAssetSelectOptions.ts
+++ b/src/modules/transactions/hooks/assets/useAssetSelectOptions.ts
@@ -15,6 +15,7 @@ interface UseAssetSelectOptionsProps {
   assets?: Asset[];
   nfts?: NFT[];
   recipients?: ITransactionField[];
+  getBalanceAvailable: (assetValue: string) => string;
 }
 
 const formatAsset = (asset: Asset) => ({
@@ -42,8 +43,10 @@ const filterNFTs = (
   return filteredNFTs;
 };
 
-const useAssetSelectOptions = (props: UseAssetSelectOptionsProps) => {
-  const { currentAsset, recipients, assets, nfts } = props;
+const useAssetSelectOptions = (
+  props: UseAssetSelectOptionsProps,
+): { assetsOptions: { label: string; value: string }[] } => {
+  const { currentAsset, recipients, assets, nfts, getBalanceAvailable } = props;
 
   const { assetsMap } = useWorkspaceContext();
 
@@ -54,7 +57,14 @@ const useAssetSelectOptions = (props: UseAssetSelectOptionsProps) => {
   const sortedAssets = useSortTokenInfosArray(_assets, assetsMap);
   const formattedAssets = sortedAssets.map(formatAsset);
 
-  return { assetsOptions: [...formattedAssets, ...formattedNFTs] };
+  const filteredAssets = formattedAssets.filter((asset) => {
+    const balanceAvailableForAsset = parseFloat(
+      getBalanceAvailable(asset.value),
+    );
+    return balanceAvailableForAsset > 0;
+  });
+
+  return { assetsOptions: [...filteredAssets, ...formattedNFTs] };
 };
 
 export { useAssetSelectOptions };

--- a/src/modules/transactions/hooks/create/useCreateTransaction.ts
+++ b/src/modules/transactions/hooks/create/useCreateTransaction.ts
@@ -205,53 +205,56 @@ const useCreateTransaction = (props?: UseCreateTransactionParams) => {
     assetsMap,
   );
 
-  const getBalanceAvailable = useCallback(() => {
-    const currentAssetBalance = bn.parseUnits(
-      formattedCurrentAssetBalance?.find(
-        (asset) => asset.assetId === currentFieldAsset,
-      )?.amount ?? '0',
-    );
+  const getBalanceAvailable = useCallback(
+    (assetId?: string) => {
+      const assetToCheck = assetId ?? currentFieldAsset;
 
-    const currentAssetAmount =
-      transactionAssetsTotalAmount?.[currentFieldAsset] ?? bn(0);
+      const currentAssetBalance = bn.parseUnits(
+        formattedCurrentAssetBalance?.find(
+          (asset) => asset.assetId === assetToCheck,
+        )?.amount ?? '0',
+      );
 
-    const assetFieldsAmount = currentAssetAmount.gt(0)
-      ? currentAssetAmount.sub(bn.parseUnits(currentFieldAmount))
-      : currentAssetAmount;
+      const currentAssetAmount =
+        transactionAssetsTotalAmount?.[assetToCheck] ?? bn(0);
 
-    const balanceAvailableWithoutFee = assetFieldsAmount.gte(
-      currentAssetBalance,
-    )
-      ? bn(0)
-      : currentAssetBalance.sub(assetFieldsAmount);
+      const assetFieldsAmount = currentAssetAmount.gt(0)
+        ? currentAssetAmount.sub(bn.parseUnits(currentFieldAmount))
+        : currentAssetAmount;
 
-    const isEthTransaction = currentFieldAsset === NativeAssetId;
-    const isNFT = !!props?.nfts?.find(
-      (nft) => nft.assetId === currentFieldAsset,
-    );
-    const transactionFee = bn.parseUnits(validTransactionFee ?? '0');
+      const balanceAvailableWithoutFee = assetFieldsAmount.gte(
+        currentAssetBalance,
+      )
+        ? bn(0)
+        : currentAssetBalance.sub(assetFieldsAmount);
 
-    let balanceAvailable = '0.000';
+      const isEthTransaction = assetToCheck === NativeAssetId;
+      const isNFT = !!props?.nfts?.find((nft) => nft.assetId === assetToCheck);
+      const transactionFee = bn.parseUnits(validTransactionFee ?? '0');
 
-    if (isEthTransaction && balanceAvailableWithoutFee.gte(transactionFee)) {
-      balanceAvailable = balanceAvailableWithoutFee
-        .sub(transactionFee)
-        .format();
-    }
+      let balanceAvailable = '0.000';
 
-    if (!isEthTransaction) {
-      balanceAvailable = isNFT
-        ? bn(1)?.format({ units: -9, precision: 0 })
-        : balanceAvailableWithoutFee.format();
-    }
+      if (isEthTransaction && balanceAvailableWithoutFee.gte(transactionFee)) {
+        balanceAvailable = balanceAvailableWithoutFee
+          .sub(transactionFee)
+          .format();
+      }
 
-    return balanceAvailable;
-  }, [
-    currentFieldAmount,
-    validTransactionFee,
-    transactionAssetsTotalAmount,
-    currentVaultAssets,
-  ]);
+      if (!isEthTransaction) {
+        balanceAvailable = isNFT
+          ? bn(1)?.format({ units: -9, precision: 0 })
+          : balanceAvailableWithoutFee.format();
+      }
+
+      return balanceAvailable;
+    },
+    [
+      currentFieldAmount,
+      validTransactionFee,
+      transactionAssetsTotalAmount,
+      currentVaultAssets,
+    ],
+  );
 
   const handleClose = () => {
     props?.onClose();


### PR DESCRIPTION
# Description
Make token selection clearer by preventing consumed tokens from being available for the next recipient. Also, display thousand separators in the amount input field

# Summary
- [x] preventing consumed tokens from being available for the next recipient if they already used
- [x] display thousand separators in the amount input field
- [x] format the amount input field with decimal

# Screenshots

![image](https://github.com/user-attachments/assets/d24f62fa-d8ce-45fe-80eb-38cf3f75b102)
![image](https://github.com/user-attachments/assets/8beeae7a-f3d8-4125-a268-9ca9f03b3d9b)
![image](https://github.com/user-attachments/assets/ded75d3c-2b27-4dbb-b187-bdc69db01a14)
![image](https://github.com/user-attachments/assets/a29434e7-0774-4ef7-8fe2-aec01a01a3b6)
![image](https://github.com/user-attachments/assets/24884263-d4f1-4e66-8936-7a01fd5e0e93)


# Checklist
- [x] I reviewed my PR code before submitting
- [x] I ensured that the implementation is working correctly and did not impact other parts of the app
- [x] I implemented error handling for all actions/requests and verified how they will be displayed in the UI (or there was no error handling needed).
- [x] I mentioned the PR link in the task