### PR TITLE
Cr/fix/adjusts address book

### DIFF
--- a/src/modules/addressBook/hooks/useAddressBookMutations.ts
+++ b/src/modules/addressBook/hooks/useAddressBookMutations.ts
@@ -86,7 +86,7 @@ const useAddressBookMutations = ({
     onError: (error) => {
       const errorDescription = (
         (error as AxiosError)?.response?.data as IApiError
-      )?.detail;
+      )?.title;
 
       if (errorDescription?.includes('nickname')) {
         errorToast({
@@ -115,9 +115,15 @@ const useAddressBookMutations = ({
     },
   );
 
-  const handleUpdateContact = form.handleSubmit(async (data) => {
-    updateContactRequest.mutate({ ...data, id: contactToEdit.id });
-  });
+  const handleUpdateContact = form.handleSubmit(
+    async ({ nickname, address }) => {
+      updateContactRequest.mutate({
+        nickname,
+        address: new Address(address).toString(),
+        id: contactToEdit.id,
+      });
+    },
+  );
 
   const handleDeleteContact = async (id: string) => {
     deleteContactRequest.mutate(id);

--- a/src/modules/transactions/components/dialog/create/transactions.tsx
+++ b/src/modules/transactions/components/dialog/create/transactions.tsx
@@ -171,8 +171,8 @@ const TransactionFormField = (props: TransctionFormFieldProps) => {
                           name,
                           value,
                         );
-                        result.value = value;
                       }
+                      result.value = new Address(value).toB256();
                     }
 
                     return result;

--- a/src/modules/vault/components/dialog/create/form/steps/addresses.tsx
+++ b/src/modules/vault/components/dialog/create/form/steps/addresses.tsx
@@ -245,8 +245,8 @@ const VaultAddressesStep = (props: VaultAddressesStepProps) => {
                                       name,
                                       value,
                                     );
-                                  result.value = value;
                                 }
+                                result.value = new Address(value).toB256();
                               }
 
                               return result;


### PR DESCRIPTION
# Description
Addressbook register was not displaying errors by duplicate field in form and getting error to make updates. 
The addressbook input in vault register was not being found in case capital letters.

# Summary
- [x] Change to send only nickname, address and id to update the addressbook
- [x] Change to analysis duplicated error using the title instead detail
- [x] Implemented to transform value addressBook field in vault to a b256 

# Checklist
- [x] I reviewed my PR code before submitting
- [x] I ensured that the implementation is working correctly and did not impact other parts of the app
- [x] I implemented error handling for all actions/requests and verified how they will be displayed in the UI (or there was no error handling needed).
- [x] I mentioned the PR link in the task