### PR TITLE
fix(transaction): add verification if status = iscanceled on mobile

### DIFF
--- a/src/modules/transactions/components/TransactionCard/DetailsDialog.tsx
+++ b/src/modules/transactions/components/TransactionCard/DetailsDialog.tsx
@@ -75,12 +75,12 @@ const DetailsDialog = ({ ...props }: DetailsDialogProps) => {
     },
   } = useTransactionsContext();
 
-  const { isSigned, isCompleted, isDeclined, isReproved } = status;
+  const { isSigned, isCompleted, isDeclined, isReproved, isCanceled } = status;
 
   const awaitingAnswer =
     !isSigned && !isDeclined && !isCompleted && !isReproved && transaction;
 
-  const showSignActions = awaitingAnswer && isSigner;
+  const showSignActions = awaitingAnswer && isSigner && !isCanceled;
 
   return (
     <Dialog.Modal onClose={onClose} isOpen={isOpen}>

--- a/src/modules/transactions/components/transactionCardMobile/index.tsx
+++ b/src/modules/transactions/components/transactionCardMobile/index.tsx
@@ -43,13 +43,18 @@ const TransactionCardMobile = (props: TransactionCardMobileProps) => {
     ...transaction,
     account,
   });
-  const { isSigned, isCompleted, isDeclined, isReproved } = status;
+  const { isSigned, isCompleted, isDeclined, isReproved, isCanceled } = status;
 
   const missingSignature =
-    !isSigned && !isCompleted && !isDeclined && !isReproved;
+    !isSigned && !isCompleted && !isDeclined && !isReproved && !isCanceled;
 
   const awaitingAnswer =
-    !isSigned && !isDeclined && !isCompleted && !isReproved && transaction;
+    !isSigned &&
+    !isDeclined &&
+    !isCompleted &&
+    !isReproved &&
+    transaction &&
+    !isCanceled;
 
   const { isOpen, onOpen, onClose } = useDetailsDialog();
 


### PR DESCRIPTION
# Description
When canceling a transaction on desktop and then going to mobile, it presents the option to sign


# Summary
- [x]  remove the option to sign

# Screenshots
![image](https://github.com/user-attachments/assets/9d31caa7-aa02-4b30-b8fe-087505f739a0)


# Checklist
- [x] I reviewed my PR code before submitting
- [x] I ensured that the implementation is working correctly and did not impact other parts of the app
- [x] I implemented error handling for all actions/requests and verified how they will be displayed in the UI (or there was no error handling needed).
- [x] I mentioned the PR link in the task