### PR TITLE
feat(transactions): block create transactions when all assets used an…

### DIFF
--- a/src/components/input/amount.tsx
+++ b/src/components/input/amount.tsx
@@ -76,14 +76,11 @@ const AmountInput = (props: AmountInputProps) => (
         inputValue = `${inputValue}.00`;
       } else {
         const [integerPart, decimalPart] = inputValue.split('.');
-
         if (decimalPart.length === 1) {
           inputValue = `${integerPart}.${decimalPart}0`;
         }
       }
-      if (inputValue === '.00') {
-        inputValue = '0.00';
-      }
+
       event.target.value = inputValue;
       props.onChange?.(event);
     }}

--- a/src/components/input/amount.tsx
+++ b/src/components/input/amount.tsx
@@ -76,6 +76,7 @@ const AmountInput = (props: AmountInputProps) => (
         inputValue = `${inputValue}.00`;
       } else {
         const [integerPart, decimalPart] = inputValue.split('.');
+
         if (decimalPart.length === 1) {
           inputValue = `${integerPart}.${decimalPart}0`;
         }

--- a/src/components/input/amount.tsx
+++ b/src/components/input/amount.tsx
@@ -81,7 +81,9 @@ const AmountInput = (props: AmountInputProps) => (
           inputValue = `${integerPart}.${decimalPart}0`;
         }
       }
-
+      if (inputValue === '.00') {
+        inputValue = '0.00';
+      }
       event.target.value = inputValue;
       props.onChange?.(event);
     }}

--- a/src/modules/transactions/components/dialog/create/transactions.tsx
+++ b/src/modules/transactions/components/dialog/create/transactions.tsx
@@ -342,7 +342,15 @@ const TransactionAccordions = (props: TransactionAccordionProps) => {
         const transaction = form.watch(`transactions.${index}`);
         const assetSlug = assets.getAssetInfo(transaction.asset)?.slug;
         const fieldState = form.getFieldState(`transactions.${index}`);
+        const resolvedLabel = form.watch(`transactions.${index}.resolvedLabel`);
 
+        let label = ' ';
+        if (resolvedLabel?.startsWith('@')) {
+          label = resolvedLabel?.split(' ')[0];
+        }
+        if (resolvedLabel === '') {
+          form.setValue(`transactions.${index}.resolvedLabel`, label);
+        }
         const hasEmptyField = Object.values(transaction).some(
           (value) => value === '',
         );
@@ -356,11 +364,14 @@ const TransactionAccordions = (props: TransactionAccordionProps) => {
           (nick) => nick.user.address === transaction.value,
         )?.nickname;
         const resolverName = getResolverName(transaction.value);
-        const recipientLabel =
+        let recipientLabel =
           contact ??
           resolverName ??
           AddressUtils.format(transaction.value) ??
-          form.watch(`transactions.${index}.resolvedLabel`);
+          label;
+        if (label?.startsWith('@')) {
+          recipientLabel = label;
+        }
         const isNFT = isNFTAsset(transaction.asset);
 
         return (

--- a/src/modules/transactions/components/dialog/create/transactions.tsx
+++ b/src/modules/transactions/components/dialog/create/transactions.tsx
@@ -342,18 +342,14 @@ const TransactionAccordions = (props: TransactionAccordionProps) => {
         const transaction = form.watch(`transactions.${index}`);
         const assetSlug = assets.getAssetInfo(transaction.asset)?.slug;
         const fieldState = form.getFieldState(`transactions.${index}`);
-        const resolvedLabel = form.watch(`transactions.${index}.resolvedLabel`);
+        let resolvedLabel = form.watch(`transactions.${index}.resolvedLabel`);
 
-        let label = ' ';
         if (resolvedLabel?.startsWith('@')) {
-          label = resolvedLabel?.split(' ')[0];
+          resolvedLabel = resolvedLabel?.split(' ')[0];
         }
-        if (resolvedLabel === '') {
-          form.setValue(`transactions.${index}.resolvedLabel`, label);
-        }
-        const hasEmptyField = Object.values(transaction).some(
-          (value) => value === '',
-        );
+        const hasEmptyField = Object.entries(transaction)
+          .filter(([key]) => key !== 'resolvedLabel')
+          .some(([, value]) => value === '');
 
         const currentAmount = form.watch(`transactions.${index}.amount`);
         const isCurrentAmountZero = Number(currentAmount) === 0;
@@ -365,12 +361,9 @@ const TransactionAccordions = (props: TransactionAccordionProps) => {
         )?.nickname;
         const resolverName = getResolverName(transaction.value);
         let recipientLabel =
-          contact ??
-          resolverName ??
-          AddressUtils.format(transaction.value) ??
-          label;
-        if (label?.startsWith('@')) {
-          recipientLabel = label;
+          contact ?? resolverName ?? AddressUtils.format(transaction.value);
+        if (resolvedLabel?.startsWith('@')) {
+          recipientLabel = resolvedLabel;
         }
         const isNFT = isNFTAsset(transaction.asset);
 

--- a/src/modules/transactions/components/dialog/create/transactions.tsx
+++ b/src/modules/transactions/components/dialog/create/transactions.tsx
@@ -9,6 +9,7 @@ import {
   FormLabel,
   HStack,
   Text,
+  Tooltip,
   VStack,
 } from '@chakra-ui/react';
 import { Address, bn, isB256 } from 'fuels';
@@ -109,7 +110,7 @@ const TransactionFormField = (props: TransctionFormFieldProps) => {
     currentAsset: asset,
     assets: assets.assets,
     nfts: assets.nfts,
-    recipients: form.watch('transactions'),
+    recipients,
     getBalanceAvailable,
   });
 
@@ -146,26 +147,29 @@ const TransactionFormField = (props: TransctionFormFieldProps) => {
             return (
               <FormControl isInvalid={fieldState.invalid}>
                 <Autocomplete
-                  value={field.value}
+                  value={
+                    form.watch(`transactions.${index}.resolvedLabel`) ||
+                    field.value
+                  }
                   label={`Recipient ${index + 1} address`}
                   onChange={field.onChange}
                   onInputChange={async (value: string) => {
-                    const result = { value: value, label: value };
+                    const result = { value, label: value };
 
                     if (value.startsWith('@')) {
                       const address = await fetchResolveAddress.handler(
                         value.split(' - ').at(0)!,
                       );
+
                       if (address) {
                         result.value = address;
                         result.label = AddressBookUtils.formatForAutocomplete(
                           value,
                           address,
                         );
+                        console.log('result.label:', result.label);
                       }
-                    }
-
-                    if (isB256(value)) {
+                    } else if (isB256(value)) {
                       const name = await fetchResolverName.handler(value);
                       if (name) {
                         result.label = AddressBookUtils.formatForAutocomplete(
@@ -176,12 +180,17 @@ const TransactionFormField = (props: TransctionFormFieldProps) => {
                       result.value = new Address(value).toB256();
                     }
 
+                    field.onChange(result.value);
+                    form.setValue(
+                      `transactions.${index}.resolvedLabel`,
+                      result.label,
+                    );
                     return result;
                   }}
                   isLoading={
                     !optionsRequests[index].isSuccess ||
                     fetchResolveAddress.isLoading ||
-                    fetchResolveAddress.isLoading
+                    fetchResolverName.isLoading
                   }
                   options={appliedOptions}
                   inView={inView}
@@ -247,7 +256,7 @@ const TransactionFormField = (props: TransctionFormFieldProps) => {
                 />
                 <FormLabel color="gray">Amount</FormLabel>
                 <FormHelperText>
-                  {parseFloat(balanceAvailable) > 0 && asset && (
+                  {!isNFT && parseFloat(balanceAvailable) > 0 && asset && (
                     <Text display="flex" alignItems="center">
                       Balance (available):{' '}
                       {isFeeCalcLoading ? (
@@ -292,7 +301,11 @@ const TransactionAccordions = (props: TransactionAccordionProps) => {
   const {
     screenSizes: { isMobile },
     providerInstance,
+    vaultDetails: {
+      assets: { isNFTAsset },
+    },
   } = useWorkspaceContext();
+
   const {
     handlers: { getResolverName },
   } = useBakoIDClient(providerInstance);
@@ -312,7 +325,6 @@ const TransactionAccordions = (props: TransactionAccordionProps) => {
       index={accordion.index}
       overflowY="auto"
       pb={isMobile ? 10 : 0}
-      // maxH={accordionHeight()}
       maxH={450}
       pr={{ base: 1, sm: 0 }}
       sx={{
@@ -323,7 +335,7 @@ const TransactionAccordions = (props: TransactionAccordionProps) => {
         '&::-webkit-scrollbar-thumb': {
           backgroundColor: '#2C2C2C',
           borderRadius: '30px',
-          height: '10px' /* Adjust the height of the scrollbar thumb */,
+          height: '10px',
         },
       }}
     >
@@ -346,87 +358,102 @@ const TransactionAccordions = (props: TransactionAccordionProps) => {
         )?.nickname;
         const resolverName = getResolverName(transaction.value);
         const recipientLabel =
-          contact ?? resolverName ?? AddressUtils.format(transaction.value);
+          contact ??
+          resolverName ??
+          form.watch(`transactions.${index}.resolvedLabel`) ??
+          AddressUtils.format(transaction.value);
+
+        const isNFT = isNFTAsset(transaction.asset);
 
         return (
-          <>
-            <AccordionItem
-              key={field.id}
-              mb={6}
-              borderWidth={1}
-              borderColor="grey.925"
-              borderRadius={10}
-              backgroundColor="dark.950"
-            >
-              <TransactionAccordion.Item
-                title={`Recipient ${index + 1}`}
-                actions={
-                  <TransactionAccordion.Actions>
-                    <HStack spacing={4}>
-                      <TransactionAccordion.EditAction
-                        onClick={() => accordion.open(index)}
-                      />
-                      <TransactionAccordion.DeleteAction
-                        isDisabled={props.transactions.fields.length === 1}
-                        onClick={() => {
-                          transactions.remove(index);
-                          accordion.close();
-                        }}
-                      />
-                    </HStack>
-                    <TransactionAccordion.ConfirmAction
-                      onClick={() => accordion.close()}
-                      isDisabled={isDisabled}
-                      isLoading={
-                        !isCurrentAmountZero ? isFeeCalcLoading : false
-                      }
+          <AccordionItem
+            key={field.id}
+            mb={6}
+            borderWidth={1}
+            borderColor="grey.925"
+            borderRadius={10}
+            backgroundColor="dark.950"
+          >
+            <TransactionAccordion.Item
+              title={`Recipient ${index + 1}`}
+              actions={
+                <TransactionAccordion.Actions>
+                  <HStack spacing={4}>
+                    <TransactionAccordion.EditAction
+                      onClick={() => accordion.open(index)}
                     />
-                  </TransactionAccordion.Actions>
-                }
-                resume={
-                  !hasEmptyField && (
-                    <Text fontSize="sm" color="grey.500" mt={2}>
-                      <b>
-                        {transaction.amount} {assetSlug}
-                      </b>{' '}
-                      to <b> {recipientLabel}</b>
-                    </Text>
-                  )
-                }
-              >
-                <TransactionFormField
-                  index={index}
-                  form={form}
-                  assets={assets}
-                  isFeeCalcLoading={isFeeCalcLoading}
-                  getBalanceAvailable={getBalanceAvailable}
-                />
-              </TransactionAccordion.Item>
-            </AccordionItem>
-          </>
+                    <TransactionAccordion.DeleteAction
+                      isDisabled={props.transactions.fields.length === 1}
+                      onClick={() => {
+                        transactions.remove(index);
+                        accordion.close();
+                      }}
+                    />
+                  </HStack>
+                  <TransactionAccordion.ConfirmAction
+                    onClick={() => accordion.close()}
+                    isDisabled={isDisabled}
+                    isLoading={!isCurrentAmountZero ? isFeeCalcLoading : false}
+                  />
+                </TransactionAccordion.Actions>
+              }
+              resume={
+                !hasEmptyField && (
+                  <Text fontSize="sm" color="grey.500" mt={2}>
+                    <b>
+                      {isNFT ? 'NFT' : transaction.amount}{' '}
+                      {isNFT ? '' : assetSlug}
+                    </b>{' '}
+                    to <b> {recipientLabel}</b>
+                  </Text>
+                )
+              }
+            >
+              <TransactionFormField
+                index={index}
+                form={form}
+                assets={assets}
+                isFeeCalcLoading={isFeeCalcLoading}
+                getBalanceAvailable={getBalanceAvailable}
+              />
+            </TransactionAccordion.Item>
+          </AccordionItem>
         );
       })}
+
       <Center mt={6}>
-        <Button
-          w="full"
-          leftIcon={<UserAddIcon />}
-          variant="primary"
-          bgColor="grey.200"
-          border="none"
-          _hover={{
-            opacity: 0.8,
-          }}
-          onClick={() => {
-            transactions.append({
-              amount: '',
-              asset: NativeAssetId,
-              value: '',
-            });
-            delay(() => accordion.open(transactions.fields.length), 100);
-          }}
+        <Tooltip
+          label="All available assets have been used."
+          isDisabled={!form.allAssetsUsed}
+          hasArrow
+          placement="top"
         >
-          Add more recipients
-        </Button>
+          <Button
+            w="full"
+            leftIcon={<UserAddIcon />}
+            variant="primary"
+            bgColor="grey.200"
+            border="none"
+            _hover={{
+              opacity: 0.8,
+            }}
+            _disabled={{
+              cursor: 'not-allowed',
+              opacity: 0.6,
+            }}
+            isDisabled={form.allAssetsUsed}
+            onClick={() => {
+              transactions.append({
+                amount: '',
+                asset: NativeAssetId,
+                value: '',
+              });
+              delay(() => accordion.open(transactions.fields.length), 100);
+            }}
+          >
+            Add more recipients
+          </Button>
+        </Tooltip>
       </Center>
     </Accordion>
   );

--- a/src/modules/transactions/components/dialog/create/transactions.tsx
+++ b/src/modules/transactions/components/dialog/create/transactions.tsx
@@ -155,7 +155,6 @@ const TransactionFormField = (props: TransctionFormFieldProps) => {
                   onChange={field.onChange}
                   onInputChange={async (value: string) => {
                     const result = { value, label: value };
-
                     if (value.startsWith('@')) {
                       const address = await fetchResolveAddress.handler(
                         value.split(' - ').at(0)!,
@@ -360,9 +359,8 @@ const TransactionAccordions = (props: TransactionAccordionProps) => {
         const recipientLabel =
           contact ??
           resolverName ??
-          form.watch(`transactions.${index}.resolvedLabel`) ??
-          AddressUtils.format(transaction.value);
-
+          AddressUtils.format(transaction.value) ??
+          form.watch(`transactions.${index}.resolvedLabel`);
         const isNFT = isNFTAsset(transaction.asset);
 
         return (

--- a/src/modules/transactions/hooks/create/useCreateTransaction.ts
+++ b/src/modules/transactions/hooks/create/useCreateTransaction.ts
@@ -2,7 +2,8 @@ import { useMutation } from '@tanstack/react-query';
 import { IAssetGroupById } from 'bakosafe';
 import { BN, bn } from 'fuels';
 import debounce from 'lodash.debounce';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useWatch } from 'react-hook-form';
 import { useNavigate } from 'react-router-dom';
 
 import { useContactToast } from '@/modules/addressBook';
@@ -180,6 +181,11 @@ const useCreateTransaction = (props?: UseCreateTransactionParams) => {
   const currentFieldAmount = form.watch(
     `transactions.${accordion.index}.amount`,
   );
+
+  const currentFieldAmountWithoutCommas = currentFieldAmount
+    ? currentFieldAmount.replace(/,/g, '')
+    : '';
+
   const currentFieldAsset = form.watch(`transactions.${accordion.index}.asset`);
 
   const transactionTotalAmount = form
@@ -190,11 +196,11 @@ const useCreateTransaction = (props?: UseCreateTransactionParams) => {
     .watch('transactions')
     ?.reduce((acc, tx) => {
       const { asset, amount } = tx;
-
+      const amountWithoutCommas = amount.replace(/,/g, '');
       if (!acc[asset]) {
-        acc[asset] = bn.parseUnits(amount);
+        acc[asset] = bn.parseUnits(amountWithoutCommas);
       } else {
-        acc[asset] = acc[asset].add(bn.parseUnits(amount));
+        acc[asset] = acc[asset].add(bn.parseUnits(amountWithoutCommas));
       }
 
       return acc;
@@ -219,7 +225,7 @@ const useCreateTransaction = (props?: UseCreateTransactionParams) => {
         transactionAssetsTotalAmount?.[assetToCheck] ?? bn(0);
 
       const assetFieldsAmount = currentAssetAmount.gt(0)
-        ? currentAssetAmount.sub(bn.parseUnits(currentFieldAmount))
+        ? currentAssetAmount.sub(bn.parseUnits(currentFieldAmountWithoutCommas))
         : currentAssetAmount;
 
       const balanceAvailableWithoutFee = assetFieldsAmount.gte(
@@ -266,6 +272,52 @@ const useCreateTransaction = (props?: UseCreateTransactionParams) => {
     }, 300),
     [],
   );
+
+  const transactionsForm = useWatch({
+    control: form.control,
+    name: 'transactions',
+    defaultValue: [],
+  });
+
+  const allAssetsUsed = useMemo(() => {
+    if (!transactionsForm?.length) return false;
+
+    const transactionAssetIds = new Set(
+      transactionsForm.map((transaction) => transaction.asset),
+    );
+
+    const nfts = props?.nfts || [];
+    const allNftsInTransactions =
+      nfts.length === 0 ||
+      nfts.every((nft) => transactionAssetIds.has(nft.assetId));
+
+    const assets = currentVaultAssets || [];
+
+    const hasSufficientBalance = assets.every(({ assetId, units }) => {
+      if (!transactionAssetIds.has(assetId)) return false;
+      const available = getBalanceAvailable(assetId);
+      const assetAmount = bn.parseUnits(available, units);
+      const transactionAssets = (transactionsForm ?? []).filter(
+        (transaction) => transaction.asset === assetId,
+      );
+
+      const totalTransactionAmount = transactionAssets.reduce(
+        (sum, transaction) => {
+          const amount = bn.parseUnits(
+            (transaction.amount || '0').replace(/,/g, ''),
+          );
+          return sum.add(amount);
+        },
+        bn(0),
+      );
+
+      return assetAmount.lte(totalTransactionAmount);
+    });
+
+    const hasBalance = allNftsInTransactions && hasSufficientBalance;
+
+    return hasBalance;
+  }, [currentVaultAssets, getBalanceAvailable, props?.nfts, transactionsForm]);
 
   useEffect(() => {
     const _transactionFee =
@@ -334,6 +386,7 @@ const useCreateTransaction = (props?: UseCreateTransactionParams) => {
       ...form,
       handleCreateTransaction,
       handleCreateAndSignTransaction,
+      allAssetsUsed,
     },
     nicks: listContactsRequest.data ?? [],
     navigate,

--- a/src/modules/transactions/hooks/create/useCreateTransactionForm.ts
+++ b/src/modules/transactions/hooks/create/useCreateTransactionForm.ts
@@ -17,11 +17,12 @@ export interface ITransactionField {
   value: string;
   amount: string;
   fee?: string;
+  resolvedLabel?: string;
 }
 
 export type UseCreateTransactionFormParams = {
   assets?: { assetId: string; amount: string }[];
-  nfts?: { assetId: string; amount: string }[];
+  nfts?: { assetId: string }[];
   assetsMap: AssetMap;
   validateBalance: (asset: string, amount: string) => boolean;
   getCoinAmount: (asset: string) => BN;
@@ -193,6 +194,7 @@ const useCreateTransactionForm = (params: UseCreateTransactionFormParams) => {
             }
           },
         ),
+      resolvedLabel: yup.string().optional(),
     });
 
     const schema = yup.object({
@@ -217,6 +219,7 @@ const useCreateTransactionForm = (params: UseCreateTransactionFormParams) => {
           value: '',
           amount: '',
           fee: '',
+          resolvedLabel: '',
         },
       ],
     },


### PR DESCRIPTION
# Description
Show addres after editing transaction card and block create transactions when all assets used

# Summary
- [x] Show addres after editing transaction card 
- [x] block create transactions when all assets used

# Screenshots
![image](https://github.com/user-attachments/assets/cb43510c-cee7-42e6-9098-9fa7588e5e18)

# Checklist
- [x] I reviewed my PR code before submitting
- [x] I ensured that the implementation is working correctly and did not impact other parts of the app
- [x] I implemented error handling for all actions/requests and verified how they will be displayed in the UI (or there was no error handling needed).
- [x] I mentioned the PR link in the task