### PR TITLE
fix(addres): if user add a passkey the field address will trigger a n…

### DIFF
--- a/src/modules/transactions/hooks/create/useCreateTransactionForm.ts
+++ b/src/modules/transactions/hooks/create/useCreateTransactionForm.ts
@@ -186,7 +186,9 @@ const useCreateTransactionForm = (params: UseCreateTransactionFormParams) => {
               const isValid =
                 AddressUtils.isValid(address) && !isAssetIdOrAssetAddress;
               if (!isValid) return false;
-
+              if (AddressUtils.isPasskey(address)) {
+                return false;
+              }
               return addressValidator.isValid(address);
             } catch {
               return false;


### PR DESCRIPTION
# Description
If the user tries to send a transaction to a WebAuthum address, the system should display an error message below the input.


# Summary
- [x] add error msg when tries to send a transaction to a WebAuthum address


# Screenshots
![image](https://github.com/user-attachments/assets/fb507394-21b0-47da-a8d2-7d688d686731)

# Checklist
- [x] I reviewed my PR code before submitting
- [x] I ensured that the implementation is working correctly and did not impact other parts of the app
- [x] I implemented error handling for all actions/requests and verified how they will be displayed in the UI (or there was no error handling needed).
- [x] I mentioned the PR link in the task