### PR TITLE
fix(transactions): vaults are no more stucks with other vault has a p…

### DIFF
--- a/src/modules/transactions/hooks/list/useTotalSignaturesPendingRequest.ts
+++ b/src/modules/transactions/hooks/list/useTotalSignaturesPendingRequest.ts
@@ -10,7 +10,7 @@ export type IUseTransactionSignaturePendingReturn = ReturnType<
 
 const useTransactionsSignaturePending = (predicateId?: string[]) => {
   return useQuery({
-    queryKey: [PENDING_TRANSACTIONS_QUERY_KEY],
+    queryKey: [PENDING_TRANSACTIONS_QUERY_KEY, predicateId],
     queryFn: () => {
       return TransactionService.getTransactionsSignaturePending(predicateId);
     },

--- a/src/modules/transactions/hooks/list/useTransactionListPaginationRequest.ts
+++ b/src/modules/transactions/hooks/list/useTransactionListPaginationRequest.ts
@@ -38,7 +38,11 @@ const useTransactionListPaginationRequest = (
         orderBy: TransactionOrderBy.CREATED_AT,
         sort: SortOptionTx.DESC,
       }).then((data) => {
-        invalidateQueries([PENDING_TRANSACTIONS_QUERY_KEY]);
+        const keysToInvalidate = [PENDING_TRANSACTIONS_QUERY_KEY];
+        if (params.predicateId?.length) {
+          keysToInvalidate.push(params.predicateId[0]);
+        }
+        invalidateQueries(keysToInvalidate);
         return data;
       }),
     enabled: window.location.pathname != '/',

--- a/src/modules/vault/components/modal/hook.ts
+++ b/src/modules/vault/components/modal/hook.ts
@@ -40,7 +40,6 @@ const useVaultDrawer = (props: UseVaultDrawerParams) => {
       handlers: { setSelectedTransaction, selectedTransaction },
     },
     resetAllTransactionsTypeFilters,
-    pendingSignerTransactions,
   } = useTransactionsContext();
 
   const vaultList = useVaultListRequest(
@@ -97,10 +96,6 @@ const useVaultDrawer = (props: UseVaultDrawerParams) => {
         workspaceId: userInfos.workspace?.id,
       }),
     );
-
-    setTimeout(() => {
-      pendingSignerTransactions.refetch();
-    }, 100);
   };
 
   const onCloseDrawer = () => {

--- a/src/modules/vault/components/modal/hook.ts
+++ b/src/modules/vault/components/modal/hook.ts
@@ -40,6 +40,7 @@ const useVaultDrawer = (props: UseVaultDrawerParams) => {
       handlers: { setSelectedTransaction, selectedTransaction },
     },
     resetAllTransactionsTypeFilters,
+    pendingSignerTransactions,
   } = useTransactionsContext();
 
   const vaultList = useVaultListRequest(
@@ -96,6 +97,10 @@ const useVaultDrawer = (props: UseVaultDrawerParams) => {
         workspaceId: userInfos.workspace?.id,
       }),
     );
+
+    setTimeout(() => {
+      pendingSignerTransactions.refetch();
+    }, 100);
   };
 
   const onCloseDrawer = () => {


### PR DESCRIPTION
…ending transaction

# Description
If the account has a pending transaction, regardless of the vault, ALL other vaults will have the "send" button blocked and the "pending transaction" message displayed.


# Summary
- [x] unblock other vaults with no pending transactions

# Checklist
- [x] I reviewed my PR code before submitting
- [x] I ensured that the implementation is working correctly and did not impact other parts of the app
- [x] I implemented error handling for all actions/requests and verified how they will be displayed in the UI (or there was no error handling needed).
- [x] I mentioned the PR link in the task