### PR TITLE
fix(tx): block button on recalculate gas, padronize colors

### DIFF
--- a/src/components/autocomplete/basic.tsx
+++ b/src/components/autocomplete/basic.tsx
@@ -54,7 +54,6 @@ interface AutocompleteProps extends Omit<InputGroupProps, 'onChange'> {
   actionOnBlur?: () => void;
   inputRef?: LegacyRef<HTMLInputElement>;
 }
-// import { useCallback, useEffect, useRef, useState } from 'react';
 
 const Autocomplete = ({
   label,

--- a/src/modules/addressBook/components/addToAddressBook/index.tsx
+++ b/src/modules/addressBook/components/addToAddressBook/index.tsx
@@ -14,7 +14,7 @@ const AddToAddressBook = ({ visible = true, onAdd }: AddToAddressBookProps) => {
 
   return (
     <Box mt={2}>
-      <Text color="grey.200" fontSize={12}>
+      <Text color="grey.425" fontSize={12}>
         Do you wanna{' '}
         <Link color="brand.500" onClick={onAdd}>
           add this

--- a/src/modules/transactions/components/dialog/create/form.tsx
+++ b/src/modules/transactions/components/dialog/create/form.tsx
@@ -15,6 +15,10 @@ import { UseCreateTransaction } from '@/modules/transactions/hooks';
 import { UseVaultDetailsReturn } from '@/modules/vault';
 
 import { Recipient } from './recipient';
+import { useWorkspaceContext } from '@/modules/workspace/WorkspaceProvider';
+import { useBakoIDClient } from '@/modules/core/hooks/bako-id';
+import { useEffect, useMemo, useState } from 'react';
+import { bn } from 'fuels';
 
 export interface CreateTransactionFormProps extends BoxProps {
   form: UseCreateTransaction['form'];
@@ -36,6 +40,53 @@ const CreateTransactionForm = (props: CreateTransactionFormProps) => {
     isFeeCalcLoading,
     getBalanceAvailable,
   } = props;
+
+  const {
+    providerInstance,
+  } = useWorkspaceContext();
+
+  const [ethAssetId, setEthAssetId] = useState<string | undefined>();
+
+  useEffect(() => {
+    const fetchEthAssetId = async () => {
+      const provider = await providerInstance;
+      const baseAssetId = await provider.getBaseAssetId();
+      setEthAssetId(baseAssetId);
+    };
+
+    fetchEthAssetId();
+  }, [providerInstance]);
+
+  const { hasEthForFee } = useMemo(() => {
+    if (!ethAssetId) return { hasEthForFee: false };
+
+    let feeAlreadyAdded = false;
+
+    const used = transactionsFields.fields.reduce((acc, _, index) => {
+      const transaction = form.watch(`transactions.${index}`);
+      if (transaction.asset !== ethAssetId) return acc;
+
+      const amount = Number(transaction.amount || 0);
+      let fee = 0;
+
+      if (!feeAlreadyAdded) {
+        fee = Number(transaction.fee || 0);
+        feeAlreadyAdded = true;
+      }
+
+      return acc + amount + fee;
+    }, 0);
+
+    const asset = assets.assets?.find((a) => a.assetId === ethAssetId);
+    const totalEth = asset?.amount ? bn(asset.amount).formatUnits() : 0;
+
+    const hasEnough = Number(totalEth) >= Number(used.toFixed(9));
+
+    return {
+      totalEthUsed: used,
+      hasEthForFee: hasEnough,
+    };
+  }, [transactionsFields, form, assets.assets, ethAssetId]);
 
   return (
     <FormProvider {...form}>
@@ -78,6 +129,8 @@ const CreateTransactionForm = (props: CreateTransactionFormProps) => {
           accordion={accordion}
           transactions={transactionsFields}
           allAssetsUsed={form.allAssetsUsed}
+          hasEthForFee={hasEthForFee}
+          ethAssetId={ethAssetId}
         >
           {transactionsFields.fields.map((transaction, index) => (
             <Recipient.Item
@@ -90,6 +143,8 @@ const CreateTransactionForm = (props: CreateTransactionFormProps) => {
               onDelete={transactionsFields.remove}
               nicks={nicks}
               index={index}
+              hasEthForFee={hasEthForFee}
+              ethAssetId={ethAssetId}
             />
           ))}
         </Recipient.List>

--- a/src/modules/transactions/components/dialog/create/recipient/Form.tsx
+++ b/src/modules/transactions/components/dialog/create/recipient/Form.tsx
@@ -132,10 +132,10 @@ const RecipientFormField = (props: RecipientFormFieldProps) => {
           name={`transactions.${index}.value`}
           control={control}
           render={({ field, fieldState }) => {
+
             const appliedOptions = optionsRequests[index].options.filter(
               (a) => Address.fromString(a.value).toString() !== field.value,
             );
-
             const showAddToAddressBook =
               canAddMember &&
               !fieldState.invalid &&

--- a/src/modules/transactions/components/dialog/create/recipient/Item.tsx
+++ b/src/modules/transactions/components/dialog/create/recipient/Item.tsx
@@ -79,7 +79,6 @@ const RecipientItem = ({
 
   return (
     <AccordionItem
-    key={index}
     mb={6}
     borderWidth={1}
     borderColor={

--- a/src/modules/transactions/components/dialog/create/recipient/Item.tsx
+++ b/src/modules/transactions/components/dialog/create/recipient/Item.tsx
@@ -24,6 +24,8 @@ interface RecipientItemProps {
   accordion: UseCreateTransaction['accordion'];
   isFeeCalcLoading: boolean;
   getBalanceAvailable: UseCreateTransaction['getBalanceAvailable'];
+  hasEthForFee:boolean;
+  ethAssetId: string | undefined;
 }
 
 const RecipientItem = ({
@@ -35,6 +37,8 @@ const RecipientItem = ({
   accordion,
   isFeeCalcLoading,
   getBalanceAvailable,
+  hasEthForFee,
+  ethAssetId
 }: RecipientItemProps) => {
   const { watch, getFieldState } = useFormContext<ITransactionForm>();
   const {
@@ -75,11 +79,18 @@ const RecipientItem = ({
 
   return (
     <AccordionItem
-      mb={6}
-      borderWidth={1}
-      borderColor="grey.925"
-      borderRadius={10}
-      backgroundColor="dark.950"
+    key={index}
+    mb={6}
+    borderWidth={1}
+    borderColor={
+      !hasEthForFee &&
+      transaction.asset === ethAssetId &&
+      !isCurrentAmountZero
+        ? 'red.500'
+        : 'grey.925'
+    }
+    borderRadius={10}
+    backgroundColor="dark.950"
     >
       <TransactionAccordion.Item
         title={`Recipient ${index + 1}`}

--- a/src/modules/transactions/components/dialog/create/recipient/List.tsx
+++ b/src/modules/transactions/components/dialog/create/recipient/List.tsx
@@ -1,4 +1,4 @@
-import { Accordion, Button, Center, Tooltip } from '@chakra-ui/react';
+import { Accordion, Button, Center, Text, Tooltip } from '@chakra-ui/react';
 import { memo } from 'react';
 
 import { UserAddIcon } from '@/components';
@@ -11,6 +11,8 @@ interface RecipientListProps {
   transactions: UseCreateTransaction['transactionsFields'];
   children: React.ReactNode;
   allAssetsUsed: boolean;
+  hasEthForFee:boolean;
+  ethAssetId: string | undefined;
 }
 
 export const RecipientList = ({
@@ -18,6 +20,8 @@ export const RecipientList = ({
   accordion,
   children,
   allAssetsUsed,
+  hasEthForFee,
+  ethAssetId
 }: RecipientListProps) => {
   const {
     screenSizes: { isMobile },
@@ -26,12 +30,12 @@ export const RecipientList = ({
   const handleAddMoreRecipient = () => {
     transactions.append({
       amount: '',
-      asset: NativeAssetId,
+      asset: ethAssetId ? ethAssetId : '',
       value: '',
     });
     delay(() => accordion.open(transactions.fields.length), 100);
   };
-
+  
   return (
     <Accordion
       index={accordion.index}
@@ -53,32 +57,44 @@ export const RecipientList = ({
     >
       {children}
 
-      <Center mt={6}>
-        <Tooltip
-          label="All available assets have been used."
-          isDisabled={!allAssetsUsed}
-          hasArrow
-          placement="top"
-        >
-          <Button
+      <Center mt={6} flexDirection="column" w="full">
+        {!hasEthForFee ? (
+          <Text
+            color="error.500"
+            fontSize="sm"
             w="full"
-            leftIcon={<UserAddIcon />}
-            variant="primary"
-            bgColor="grey.200"
-            border="none"
-            _hover={{
-              opacity: 0.8,
-            }}
-            _disabled={{
-              cursor: 'not-allowed',
-              opacity: 0.6,
-            }}
-            isDisabled={allAssetsUsed}
-            onClick={handleAddMoreRecipient}
+            textAlign="center"
+            mt={2}
           >
-            Add more recipients
-          </Button>
-        </Tooltip>
+            Insufficient funds for gas
+          </Text>
+        ) : (
+          <Tooltip
+            label="All available assets have been used."
+            isDisabled={!allAssetsUsed}
+            hasArrow
+            placement="top"
+          >
+            <Button
+              w="full"
+              leftIcon={<UserAddIcon />}
+              variant="primary"
+              bgColor="grey.200"
+              border="none"
+              _hover={{
+                opacity: 0.8,
+              }}
+              _disabled={{
+                cursor: 'not-allowed',
+                opacity: 0.6,
+              }}
+              isDisabled={allAssetsUsed}
+              onClick={handleAddMoreRecipient}
+            >
+              Add more recipients
+            </Button>
+          </Tooltip>
+        )}
       </Center>
     </Accordion>
   );

--- a/src/modules/transactions/components/dialog/create/transactions.tsx
+++ b/src/modules/transactions/components/dialog/create/transactions.tsx
@@ -234,12 +234,12 @@ const TransactionFormField = (props: TransctionFormFieldProps) => {
                         position="absolute"
                         top="50%"
                         right="0.5rem"
-                        bg="#201F1D"
+                        bg="grey.825"
                         padding="0.5rem"
                         paddingTop={'20px'}
                         paddingBottom={'20px'}
                         borderRadius="md"
-                        _hover={{ bg: '#201F1D' }}
+                        _hover={{ bg: 'grey.825' }}
                         color={'white'}
                         transform="translateY(-50%)"
                         zIndex={1}
@@ -295,7 +295,7 @@ const TransactionFormField = (props: TransctionFormFieldProps) => {
                   }}
                   helperText={
                     <FormHelperText
-                      color={fieldState.error ? 'error.500' : 'white'}
+                      color={fieldState.error ? 'error.500' : 'grey.425'}
                     >
                       {!isNFT && (
                         <Text display="flex" alignItems="center" mt={1}>
@@ -309,7 +309,7 @@ const TransactionFormField = (props: TransctionFormFieldProps) => {
                                   trackColor="dark.100"
                                   size={3}
                                   isIndeterminate
-                                  color="brand.500"
+                                  color="grey.425"
                                   ml={1}
                                 />
                               </>
@@ -335,12 +335,12 @@ const TransactionFormField = (props: TransctionFormFieldProps) => {
                     position="absolute"
                     top={isNFT ? '47%' : '38%'}
                     right="0.5rem"
-                    bg="#201F1D"
+                    bg="grey.825"
                     padding="0.5rem"
                     paddingTop={'20px'}
                     paddingBottom={'20px'}
                     borderRadius="md"
-                    _hover={{ bg: '#201F1D' }}
+                    _hover={{ bg: 'grey.825' }}
                     color={'white'}
                     transform="translateY(-50%)"
                     zIndex={1}
@@ -389,6 +389,7 @@ const TransactionFormField = (props: TransctionFormFieldProps) => {
                     <FormLabel>Amount</FormLabel>
 
                     <FormHelperText
+                      pl={4}
                       color={fieldState.invalid ? 'error.500' : 'gray.400'}
                     >
                       {fieldState.error?.message ? (
@@ -399,7 +400,7 @@ const TransactionFormField = (props: TransctionFormFieldProps) => {
                         <Text
                           fontSize="sm"
                           lineHeight="short"
-                          color="gray.500"
+                          color="grey.425"
                           opacity={usdNumber > 0 ? 1 : 0}
                         >
                           ~ {usdEstimate}
@@ -414,7 +415,7 @@ const TransactionFormField = (props: TransctionFormFieldProps) => {
                         right="0.75rem"
                         spacing={1}
                         zIndex={1}
-                        bg="#201F1D"
+                        bg="grey.825"
                         transform="translateY(-50%)"
                       >
                         <IconButton
@@ -424,8 +425,8 @@ const TransactionFormField = (props: TransctionFormFieldProps) => {
                           variant="ghost"
                           color={'white'}
                           padding={4}
-                          bg="201F1D"
-                          _hover={{ bg: '#201F1D' }}
+                          bg="grey.825"
+                          _hover={{ bg: 'grey.825' }}
                           zIndex={1}
                           onClick={() => field.onChange('')}
                         />
@@ -437,12 +438,14 @@ const TransactionFormField = (props: TransctionFormFieldProps) => {
                           borderRadius="md"
                           color={'white'}
                           fontWeight="bold"
+                          pt={1}
                           _hover={{
                             bg: 'grey.900',
                           }}
                           _active={{
                             bg: 'grey.850',
                           }}
+                          isDisabled={isFeeCalcLoading}
                           onClick={() => {
                             const max = getBalanceAvailable();
                             field.onChange(max);
@@ -542,7 +545,7 @@ const TransactionAccordions = (props: TransactionAccordionProps) => {
           maxHeight: '330px',
         },
         '&::-webkit-scrollbar-thumb': {
-          backgroundColor: '#2C2C2C',
+          backgroundColor: 'grey.300',
           borderRadius: '30px',
           height: '10px',
         },


### PR DESCRIPTION
# Description
Tx Form Settings

# Summary
- [x] In the Tx creation form, leave the three texts marked, in the same color, to maintain the standard
- [x] Block button max on calculate fee

# Checklist
- [x] I reviewed my PR code before submitting
- [x] I ensured that the implementation is working correctly and did not impact other parts of the app
- [x] I implemented error handling for all actions/requests and verified how they will be displayed in the UI (or there was no error handling needed).
- [x] I mentioned the PR link in the task