### PR TITLE
fix(estimate dollar): removing the comma before do the calc

### DIFF
--- a/src/modules/transactions/components/dialog/create/recipient/Form.tsx
+++ b/src/modules/transactions/components/dialog/create/recipient/Form.tsx
@@ -109,7 +109,7 @@ const RecipientFormField = (props: RecipientFormFieldProps) => {
   const formatUsdEstimate = (amount: string, assetId: string) => {
     if (!amount || !assetId) return '$0.00';
     const price = getAssetPrice(assetId);
-    const estimated = parseFloat(amount) * price;
+    const estimated = parseFloat(amount.replace(/,/g, '')) * price;
 
     return estimated.toLocaleString('en-US', {
       style: 'currency',


### PR DESCRIPTION
# Description
Fix conversion dollar in create transaction estimative

# Summary
    - [x] removed comma before the do the calculation

# Checklist
- [x] I reviewed my PR code before submitting
- [x] I ensured that the implementation is working correctly and did not impact other parts of the app
- [x] I implemented error handling for all actions/requests and verified how they will be displayed in the UI (or there was no error handling needed).
- [x] I mentioned the PR link in the task