### PR TITLE
feat(validation): add validation to not allow addr evm in create tx

### DIFF
--- a/src/modules/core/utils/address.ts
+++ b/src/modules/core/utils/address.ts
@@ -8,10 +8,10 @@ export enum Batch32Prefix {
 export type Batch32 = `${Batch32Prefix}.${string}`;
 
 export class AddressUtils {
-  static isValid(address: string) {
+  static isValid(address: string, allowEvm = true) {
     try {
       return (
-        BakoAddressUtils.isEvm(address) ||
+        (allowEvm && BakoAddressUtils.isEvm(address)) ||
         BakoAddressUtils.isPasskey(address) ||
         isB256(address)
       );

--- a/src/modules/transactions/hooks/create/useCreateTransactionForm.ts
+++ b/src/modules/transactions/hooks/create/useCreateTransactionForm.ts
@@ -181,9 +181,10 @@ const useCreateTransactionForm = (params: UseCreateTransactionFormParams) => {
       value: yup
         .string()
         .required('Address is required.')
-        .test('valid-address', 'Invalid address.', (address) =>
-          AddressUtils.isValid(address),
-        )
+        .test('valid-address', 'Invalid address.', (address) => {
+          const allowEvm = true;
+          return AddressUtils.isValid(address, !allowEvm);
+        })
         .test(
           'valid-account',
           'This address can not receive assets from Bako.',


### PR DESCRIPTION
# Description
Fix validation input addres in create tx, not allow evm address

# Summary
 - [x] Change validation addres in transaction input form

# Checklist
- [x] I reviewed my PR code before submitting
- [x] I ensured that the implementation is working correctly and did not impact other parts of the app
- [x] I implemented error handling for all actions/requests and verified how they will be displayed in the UI (or there was no error handling needed).
- [ ] I mentioned the PR link in the task