### PR TITLE
fix(not show conversion): remove comma before calc in vault balance and details

### DIFF
--- a/src/modules/core/components/assetBalance/assets-balance-card.tsx
+++ b/src/modules/core/components/assetBalance/assets-balance-card.tsx
@@ -1,8 +1,10 @@
 import { Image, Text, VStack } from '@chakra-ui/react';
+
+import { Card } from '@/components';
 import { Asset } from '@/modules/core/utils';
 import { useWorkspaceContext } from '@/modules/workspace/WorkspaceProvider';
+
 import { useGetTokenInfos } from '../../hooks';
-import { Card } from '@/components';
 
 const AssetsBalanceCard = ({
   asset,
@@ -14,7 +16,9 @@ const AssetsBalanceCard = ({
   const { assetsMap } = useWorkspaceContext();
   const { assetAmount, assetsInfo } = useGetTokenInfos({ ...asset, assetsMap });
 
-  const transactionAmount = Number(assetAmount) * (usdAmount ?? 0);
+  const transactionAmount =
+    Number(assetAmount.replace(/,/g, '')) * (usdAmount ?? 0);
+
   const formattedAmount = new Intl.NumberFormat('en-US', {
     style: 'currency',
     currency: 'USD',

--- a/src/modules/core/components/cardAsset/index.tsx
+++ b/src/modules/core/components/cardAsset/index.tsx
@@ -63,7 +63,7 @@ const AssetDetails = ({
 }: AssetDetailsProps) => {
   const amount = assetAmount ?? defaultAsset.amount;
   const slug = assetSlug ?? defaultAsset.slug;
-  const transactionAmount = Number(amount) * (usdAmount ?? 0);
+  const transactionAmount = Number(amount.replace(/,/g, '')) * (usdAmount ?? 0);
 
   const formattedAmount = new Intl.NumberFormat('en-US', {
     style: 'currency',


### PR DESCRIPTION
# Description
Not showing conversion dollar when value is above 1,000

# Summary
- [x] remove comma before calc in vault balance and vault details 

# Checklist
- [x] I reviewed my PR code before submitting
- [x] I ensured that the implementation is working correctly and did not impact other parts of the app
- [x] I implemented error handling for all actions/requests and verified how they will be displayed in the UI (or there was no error handling needed).
- [x] I mentioned the PR link in the task