### PR TITLE
fix(assets): add fallback image on error to load the image of asset

### DIFF
--- a/src/components/select/asset.tsx
+++ b/src/components/select/asset.tsx
@@ -3,6 +3,7 @@ import { Box, Flex, Image, Stack, Text, VStack } from '@chakra-ui/react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { ArrowDownIcon } from '../icons';
+import { UNKNOWN_ASSET } from '@/modules';
 
 interface AssetSelectOption {
   value: string;
@@ -348,6 +349,8 @@ const AssetSelect = ({
                 >
                   <Image
                     src={image ?? ''}
+                    fallbackSrc={UNKNOWN_ASSET.icon}
+                    fallbackStrategy="onError"
                     boxSize={8}
                     rounded={'lg'}
                     flexShrink={0}

--- a/src/modules/transactions/components/TransactionCard/AssetBoxInfo.tsx
+++ b/src/modules/transactions/components/TransactionCard/AssetBoxInfo.tsx
@@ -124,6 +124,8 @@ const AssetBoxInfo = ({
           <Image
             w={7}
             h={7}
+            fallbackStrategy="onError"
+            fallbackSrc={assetsMap.UNKNOWN.icon}
             src={parseURI(imgUrl)}
             borderRadius="md"
             alt="Asset Icon"

--- a/src/modules/transactions/components/TransactionCard/AssetsIcon.tsx
+++ b/src/modules/transactions/components/TransactionCard/AssetsIcon.tsx
@@ -54,6 +54,8 @@ export const AssetsIcon = memo(
             <Image
               w={{ base: '30.5px', sm: 7 }}
               h={{ base: 'full', sm: 7 }}
+              fallbackSrc={assetsMap?.['UNKNOWN'].icon}
+              fallbackStrategy="onError"
               src={asset.image}
               borderRadius="md"
               alt="Asset Icon"

--- a/src/modules/transactions/components/TransactionCard/deposit-details/TokenInfos.tsx
+++ b/src/modules/transactions/components/TransactionCard/deposit-details/TokenInfos.tsx
@@ -32,6 +32,8 @@ const TokenInfos = ({ asset }: TokenInfosProps) => {
       <Image
         w={7}
         h={7}
+        fallbackStrategy="onError"
+        fallbackSrc={assetsMap?.UNKNOWN?.icon}
         src={parseURI(assetImage || assetsMap?.UNKNOWN?.icon || '')}
         borderRadius="md"
         alt="Asset Icon"


### PR DESCRIPTION
# Description
When the asset image has a broken URL, it doesn't load.

# Summary
- [x] Added a image fallback on error

# Screenshots
<!-- 
    Photos or videos of the implementation. If not necessary, remove this section.
-->

# Checklist
- [x] I reviewed my PR code before submitting
- [x] I ensured that the implementation is working correctly and did not impact other parts of the app
- [x] I implemented error handling for all actions/requests and verified how they will be displayed in the UI (or there was no error handling needed).
- [ ] I mentioned the PR link in the task