### PR TITLE
fix(block stake by not fee): recalculate fee when receive the fuel tokens

### DIFF
--- a/src/modules/vault/components/liquid-stake/ModalStake.tsx
+++ b/src/modules/vault/components/liquid-stake/ModalStake.tsx
@@ -1,4 +1,5 @@
 import { Button, Card, HStack, Image, Text, VStack } from '@chakra-ui/react';
+import { useEffect } from 'react';
 
 import { Dialog, FuelIcon } from '@/components';
 import { DoubtIcon } from '@/components/icons/doubt';
@@ -36,7 +37,14 @@ export function ModalLiquidStake({
     handleDestinationChange,
     handleSetCurrencyAmount,
     createTxLiquidStake,
+    calculateFee,
   } = useOperationLiquidStakeModal({ balance: balanceTreated, onClose });
+
+  useEffect(() => {
+    if (maxFee === 0 && Number(balance) > 0) {
+      calculateFee();
+    }
+  }, [calculateFee, maxFee, balance]);
 
   const StFUEL_ASSET = {
     name: 'stFuel',

--- a/src/modules/vault/components/liquid-stake/ModalStake.tsx
+++ b/src/modules/vault/components/liquid-stake/ModalStake.tsx
@@ -41,10 +41,10 @@ export function ModalLiquidStake({
   } = useOperationLiquidStakeModal({ balance: balanceTreated, onClose });
 
   useEffect(() => {
-    if (maxFee === 0 && Number(balance) > 0) {
+    if (maxFee === 0 && balanceTreated > 0) {
       calculateFee();
     }
-  }, [calculateFee, maxFee, balance]);
+  }, [calculateFee, maxFee, balanceTreated]);
 
   const StFUEL_ASSET = {
     name: 'stFuel',

--- a/src/modules/vault/hooks/liquid-stake/useOperationLiquidStakeModal.ts
+++ b/src/modules/vault/hooks/liquid-stake/useOperationLiquidStakeModal.ts
@@ -1,6 +1,6 @@
 import { randomBytes } from 'ethers';
 import { bn } from 'fuels';
-import { useEffect, useState } from 'react';
+import { useCallback, useState } from 'react';
 
 import { useTransactionToast } from '@/modules/transactions/providers/toast';
 import { formatMinDecimals } from '@/utils';
@@ -81,13 +81,9 @@ const useOperationLiquidStakeModal = ({
     );
   };
 
-  useEffect(() => {
-    async function getFee() {
-      const maxFee = await getMaxFee(bn(1000000));
-      if (maxFee) setMaxFee(maxFee);
-    }
-
-    getFee();
+  const calculateFee = useCallback(async () => {
+    const maxFee = await getMaxFee(bn(1000000));
+    if (maxFee) setMaxFee(maxFee);
   }, [getMaxFee]);
 
   const createTxLiquidStake = async () => {
@@ -122,6 +118,7 @@ const useOperationLiquidStakeModal = ({
     handleSourceChange,
     handleDestinationChange,
     createTxLiquidStake,
+    calculateFee,
   };
 };
 


### PR DESCRIPTION
# Description
Fix problem not able do stake when send fuel tokens to vault without refresh page

# Summary
- [x] Recalculate fee when receive fuel tokens

# Checklist
- [x] I reviewed my PR code before submitting
- [x] I ensured that the implementation is working correctly and did not impact other parts of the app
- [x] I implemented error handling for all actions/requests and verified how they will be displayed in the UI (or there was no error handling needed).
- [x] I mentioned the PR link in the task