### PR TITLE
fix(transaction): correct formatUnits behavior for different assets

### DIFF
--- a/src/modules/transactions/services/methods.ts
+++ b/src/modules/transactions/services/methods.ts
@@ -218,7 +218,7 @@ export class TransactionService {
           const newAmount = bn
             .parseUnits(currentAmount, units)
             .add(bn.parseUnits(asset.amount, units));
-          assetAmountMap.set(asset.assetId, newAmount.formatUnits());
+          assetAmountMap.set(asset.assetId, newAmount.formatUnits(units));
         }
       });
 


### PR DESCRIPTION
# Description
When trying to execute a transaction using USDC and USDT tokens, the "Create & Sign" button was disabled, preventing the transaction from proceeding. The issue was caused by incorrect decimal conversion in the amount input trigger.

Fix the decimal conversion for assets when attempting to open a transaction with USDC, USDT, or any other asset with decimals != 9.

# Summary
- [x] Fix the behavior of ``formatUnits`` by passing each asset's units as a parameter to the function.

# Checklist
- [x] I reviewed my PR code before submitting
- [x] I ensured that the implementation is working correctly and did not impact other parts of the app
- [ ] I implemented error handling for all actions/requests and verified how they will be displayed in the UI (or there was no error handling needed).
- [x] I mentioned the PR link in the task