### PR TITLE
fix(transaction-address-handler): fix the address input validation for the transaction form

### DIFF
--- a/src/modules/transactions/components/dialog/create/recipient/form/address.tsx
+++ b/src/modules/transactions/components/dialog/create/recipient/form/address.tsx
@@ -103,11 +103,7 @@ const RecipientFormAddress = ({
 
   const handleChange = useCallback(
     (value: string) => {
-      if (isB256(value)) {
-        onChange(value);
-        setInputValue(value);
-        return;
-      }
+      onChange(value);
       setInputValue(value);
     },
     [onChange],


### PR DESCRIPTION
# Description
When performing a transaction with an invalid address, the "Invalid Address" error message was not displayed to the user.

The issue occurred due to an additional validation in the input ``handleChange``, which prevented the form validation from running and, consequently, blocked the error message from being shown.

This extra validation was removed, leaving the validation responsibility solely to the form validation schema.

# Summary
- [x] Remove the extra validation from the address input’s ``handleChange``, leaving the validation responsibility to the form’s schema.

# Checklist
- [x] I reviewed my PR code before submitting
- [x] I ensured that the implementation is working correctly and did not impact other parts of the app
- [ ] I implemented error handling for all actions/requests and verified how they will be displayed in the UI (or there was no error handling needed).
- [x] I mentioned the PR link in the task