### PR TITLE
FIX: vaults without predicate version

### DIFF
--- a/src/modules/vault/components/settings/SettingsOverview.tsx
+++ b/src/modules/vault/components/settings/SettingsOverview.tsx
@@ -156,7 +156,6 @@ const SettingsOverview = ({
                 fontSize="xs"
                 lineHeight="shorter"
               >
-                {/* daqui vem a parada o predicate */}
                 {AddressUtils.format(predicateVersion || '', 4)}
                 <Clipboard.Indicator
                   copied={<Icon as={RiFileCopyFill} w="12px" />}


### PR DESCRIPTION
# Description
In the older predicates, the predicate version is not inside the configurable object. This adjustment changes the source of the predicate version to be displayed on screen.

# Summary
- [x] Changes the source of the predicate version to be displayed on screen;
- [x] An adjustment to the API was also necessary, as shown in PR https://github.com/infinitybase/bako-safe-api/pull/422

# Checklist
- [x] I reviewed my PR code before submitting
- [x] I ensured that the implementation is working correctly and did not impact other parts of the app
- [ ] I implemented error handling for all actions/requests and verified how they will be displayed in the UI (or there was no error handling needed).
- [x] I mentioned the PR link in the task