### PR TITLE
FIX: connect button remains in loading status until the popup is closed if the connection is successful

### DIFF
--- a/src/modules/dapp/pages/VaultConnector.tsx
+++ b/src/modules/dapp/pages/VaultConnector.tsx
@@ -238,8 +238,9 @@ const VaultConnector = () => {
               disabled={
                 !selectedVaultId ||
                 !vaults.length ||
+                isLoadingVaults ||
                 send.isPending ||
-                isLoadingVaults
+                send.isSuccess
               }
               onClick={() => {
                 send.mutate({
@@ -251,7 +252,7 @@ const VaultConnector = () => {
                   userAddress: userInfos.address,
                 });
               }}
-              loading={send.isPending}
+              loading={send.isPending || send.isSuccess}
             >
               Connect
             </Button>


### PR DESCRIPTION
# Description
- When the user clicks to connect, the “Connect” button becomes available before the popup is closed.

# Summary
- If the connection is successful, the “Connect” button will remain in a loading state until the popup is closed.
- If the connection fails, the button is enabled again.

# Screenshots
https://jam.dev/c/5653c7a5-45b4-483b-a26b-e953550c0c3c

# Checklist
- [x] I reviewed my PR code before submitting
- [ ] I ensured that the implementation is working correctly and did not impact other parts of the app
- [ ] I implemented error handling for all actions/requests and verified how they will be displayed in the UI (or there was no error handling needed).
- [x] I mentioned the PR link in the task