### PR TITLE
FIX: adjust NFT empty state styling to be consistent with the layout

### DIFF
--- a/src/modules/vault/components/NFTsEmptyState.tsx
+++ b/src/modules/vault/components/NFTsEmptyState.tsx
@@ -11,7 +11,7 @@ export const NFTsEmptyState = () => {
       p={{ base: 10, xs: 10 }}
       bg="gradients.transaction-card"
       borderWidth={1}
-      borderColor="gradients.transaction-border"
+      borderColor="gray.700"
       backdropFilter="blur(16px)"
       dropShadow="0px 8px 6px 0px #00000026"
       display="flex"
@@ -34,10 +34,10 @@ export const NFTsEmptyState = () => {
         />
 
         <Stack gap={2}>
-          <Text textAlign="center" color="grey.50" fontSize="md">
+          <Text textAlign="center" color="gray.200" fontSize="md" fontWeight="semibold">
             No items found
           </Text>
-          <Text textAlign="center" color="grey.250" fontSize="xs">
+          <Text textAlign="center" color="gray.400" fontSize="xs">
             Discover new collection on Marketplace
           </Text>
         </Stack>


### PR DESCRIPTION
# Description
Adjust NFT empty state colors and borders to match the design and maintain consistency with other empty states in the application.

# Summary
- [x] Updated colors of NFT empty state to match app standards
- [x] Updated border styling to align with other empty states
- [x] Verified text alignment and spacing remain consistent

# Screenshots
<img width="1512" height="639" alt="Example-3" src="https://github.com/user-attachments/assets/39f62d39-6f12-45e4-a492-62c67b9926dd" />


# Checklist
- [x] I reviewed my PR code before submitting
- [ ] I ensured that the implementation is working correctly and did not impact other parts of the app
- [x] I implemented error handling for all actions/requests and verified how they will be displayed in the UI (or there was no error handling needed).
- [x] I mentioned the PR link in the task