### PR TITLE
FIX: pending transaction state not cleared after signing

### DIFF
--- a/src/modules/transactions/components/dialog/create/index.tsx
+++ b/src/modules/transactions/components/dialog/create/index.tsx
@@ -106,7 +106,7 @@ const CreateTransactionDialog = (props: Omit<DialogModalProps, 'children'>) => {
       console.debug('Clearing pending transaction state');
       setCreateTxMethod(ECreateTransactionMethods.CREATE_AND_SIGN);
     }
-  }, [isPendingSigner, createTxMethod]);
+  }, [isPendingSigner]);
 
   return (
     <Dialog.Modal


### PR DESCRIPTION
# Description
Fixes an issue where the application continues to treat the user as having a pending transaction even after the transaction has been signed. This caused the transactions form button to remain in the “Pending Transaction” state, generating an inconsistent UI state and misleading the user.

# Summary
 - Ensures the pending transaction state is cleared immediately after the transaction is signed
 -  Updates UI state to reflect the correct button label (“Create and sign”)

# Screenshots
[Video: ](https://jam.dev/c/2867453d-7aed-44bb-850c-52149d27a376)

<img width="1916" height="908" alt="example-1" src="https://github.com/user-attachments/assets/e72f4ce8-a2cb-45fd-9829-28bac195bb18" />


# Checklist
- [x] I reviewed my PR code before submitting
- [x] I ensured that the implementation is working correctly and did not impact other parts of the app
- [ ] I implemented error handling for all actions/requests and verified how they will be displayed in the UI (or there was no error handling needed).
- [x] I mentioned the PR link in the task