### PR TITLE
fix: inconsistent address casing when copying from homepage

### DIFF
--- a/src/modules/addressBook/components/contactCard/index.tsx
+++ b/src/modules/addressBook/components/contactCard/index.tsx
@@ -9,6 +9,7 @@ import {
   useClipboard,
   VStack,
 } from 'bako-ui';
+import { Address } from 'fuels';
 import { RiFileCopyFill } from 'react-icons/ri';
 
 import { EditIcon2, IconTooltipButton, RemoveIcon } from '@/components';
@@ -37,7 +38,8 @@ const ContactCard = ({
     screenSizes: { isExtraSmall, isLitteSmall },
   } = useWorkspaceContext();
 
-  const { copy, copied } = useClipboard({ value: address });
+  const addressWithChecksum = address ? new Address(address).toString() : '';
+  const { copy, copied } = useClipboard({ value: addressWithChecksum });
 
   return (
     <Card.Root
@@ -122,7 +124,7 @@ const ContactCard = ({
 
           <Card.Footer p={0} w="full">
             <Text fontSize="xs" color="gray.300" wordBreak="break-word">
-              {address}
+              {addressWithChecksum}
             </Text>
           </Card.Footer>
         </VStack>

--- a/src/modules/vault/components/AccountOverview/index.tsx
+++ b/src/modules/vault/components/AccountOverview/index.tsx
@@ -194,7 +194,7 @@ export const AccountOverview = memo(
                   </Flex>
                 </HStack>
                 <Text fontSize="xs" color="gray.400">
-                  {AddressUtils.format(vault?.data.predicateAddress || '', 6)}
+                  {AddressUtils.format(addressWithChecksum || '', 6)}
                 </Text>
               </Card.Header>
 

--- a/src/modules/vault/components/VaultCard.tsx
+++ b/src/modules/vault/components/VaultCard.tsx
@@ -11,6 +11,7 @@ import {
   useClipboard,
   VStack,
 } from 'bako-ui';
+import { Address } from 'fuels';
 import { memo, useEffect, useMemo, useState } from 'react';
 import { RiFileCopyFill } from 'react-icons/ri';
 
@@ -55,7 +56,9 @@ export const VaultCard = memo(function VaultCard({
     id,
     workspaceId,
   );
-  const { copy, copied } = useClipboard({ value: address });
+
+  const addressWithChecksum = address ? new Address(address).toString() : '';
+  const { copy, copied } = useClipboard({ value: addressWithChecksum });
 
   const { mutate: toogleVisibility, isPending } = useMutation({
     mutationFn: VaultService.toggleVisibility,
@@ -125,7 +128,7 @@ export const VaultCard = memo(function VaultCard({
             </Heading>
 
             <Text fontSize="xs" color="gray.400" lineHeight="shorter">
-              {AddressUtils.format(address, 5)}
+              {AddressUtils.format(addressWithChecksum, 5)}
             </Text>
           </VStack>
 


### PR DESCRIPTION
# Description
Fixes an issue where copying the address from the homepage returns the value in all lowercase letters. This caused inconsistency, as copying the address from the sidebar or settings preserves the original casing. Now, all copy actions preserve the original case of the address consistently across the application.

# Summary
- Fixed address copy behavior on the homepage to preserve original casing
- Ensured consistency of copied addresses across homepage, sidebar, and settings

# Screenshots
[Video:](https://jam.dev/c/91703a67-37b1-412f-b417-2660089bb530)
<img width="1915" height="669" alt="example-1" src="https://github.com/user-attachments/assets/3d93e35c-7175-40c5-a5de-50b6f849e5ca" />


# Checklist
- [x] I reviewed my PR code before submitting
- [x] I ensured that the implementation is working correctly and did not impact other parts of the app
- [ ] I implemented error handling for all actions/requests and verified how they will be displayed in the UI (or there was no error handling needed).
- [x] I mentioned the PR link in the task