### PR TITLE
fix(export-wallet): exports predicate version outside of the config object

### DIFF
--- a/src/modules/cli/hooks/CommingSoon/useCommingSoon.tsx
+++ b/src/modules/cli/hooks/CommingSoon/useCommingSoon.tsx
@@ -74,11 +74,11 @@ const useCommingSoon = (predicateAddress: string) => {
     if (!predicateAddress) return;
 
     try {
-      const { config, name } = await ExportWallet.getByAddress({
+      const { config, version, name } = await ExportWallet.getByAddress({
         address: predicateAddress,
       });
 
-      const version = config.version;
+      const _version = config.version ?? version;
 
       if (config.version) {
         delete config.version;
@@ -86,7 +86,7 @@ const useCommingSoon = (predicateAddress: string) => {
 
       const json = {
         config,
-        version,
+        version: _version,
       };
 
       downloadJson(`${name}`, json);

--- a/src/modules/cli/services/ExportWallet/methods.ts
+++ b/src/modules/cli/services/ExportWallet/methods.ts
@@ -12,6 +12,7 @@ export class ExportWallet {
 
     return {
       config,
+      version: data.version,
       name: data.name,
     };
   }

--- a/src/modules/cli/services/ExportWallet/types.ts
+++ b/src/modules/cli/services/ExportWallet/types.ts
@@ -4,5 +4,6 @@ export interface GetPredicateByAddress {
 
 export interface GetPredicateByAddressResponse {
   name: string;
+  version: string;
   configurable: string;
 }


### PR DESCRIPTION
# Description
- The predicate version must be exported as a separate property in JSON, outside the config object.

# Summary
- Exports predicate version outside the config object
- Exports predicate version saved in the database if it does not exist in the config
- Adds capitalize to types of Export Wallet

# Checklist
- [x] I reviewed my PR code before submitting
- [ ] I ensured that the implementation is working correctly and did not impact other parts of the app
- [ ] I implemented error handling for all actions/requests and verified how they will be displayed in the UI (or there was no error handling needed).
- [ ] I mentioned the PR link in the task