### PR TITLE
FEAT: add close option to toasts to avoid UI blocking

### DIFF
--- a/src/components/addressCopy.tsx
+++ b/src/components/addressCopy.tsx
@@ -37,7 +37,6 @@ function AddressCopy({
         toast({
           position: 'top-right',
           duration: 3000,
-          isClosable: false,
           title: 'Copied to clipboard',
           icon: <Icon fontSize="2xl" color="brand.500" as={CheckIcon} />,
         });

--- a/src/components/ui/toaster.tsx
+++ b/src/components/ui/toaster.tsx
@@ -28,7 +28,7 @@ export const Toaster = () => {
             {toast.action && (
               <Toast.ActionTrigger>{toast.action.label}</Toast.ActionTrigger>
             )}
-            {toast.closable && <Toast.CloseTrigger />}
+            <Toast.CloseTrigger cursor="pointer" />
           </Toast.Root>
         )}
       </Toast.Toaster>

--- a/src/layouts/dashboard/header.tsx
+++ b/src/layouts/dashboard/header.tsx
@@ -307,7 +307,6 @@ const UserBox = () => {
                       ) {
                         toast({
                           duration: 3000,
-                          isClosable: false,
                           title: 'Copied!',
                           status: 'warning',
                           description:

--- a/src/modules/addressBook/hooks/useContactToast.tsx
+++ b/src/modules/addressBook/hooks/useContactToast.tsx
@@ -12,7 +12,6 @@ const useContactToast = () => {
     toast({
       status: 'success',
       duration: 4000,
-      isClosable: false,
       title: title ?? 'Success!',
       description: description ?? '',
     });
@@ -21,7 +20,6 @@ const useContactToast = () => {
     toast({
       status: 'warning',
       duration: 4000,
-      isClosable: false,
       title: title ?? 'Warning!',
       description: description ?? '',
     });
@@ -31,7 +29,6 @@ const useContactToast = () => {
     toast({
       status: 'error',
       duration: 4000,
-      isClosable: false,
       title: title ?? 'Error!',
       description:
         description ?? 'Check the provided data and try again, please...',

--- a/src/modules/cli/hooks/CommingSoon/useCommingSoon.tsx
+++ b/src/modules/cli/hooks/CommingSoon/useCommingSoon.tsx
@@ -63,7 +63,6 @@ const useCommingSoon = (predicateAddress: string) => {
     toast({
       status: 'success',
       duration: 5000,
-      isClosable: false,
       title: 'Email notification activated!',
       description: 'We will notify you when this feature becomes available.',
       icon: (

--- a/src/modules/settings/hooks/useSettingsToast.tsx
+++ b/src/modules/settings/hooks/useSettingsToast.tsx
@@ -15,7 +15,6 @@ const useSettingsToast = () => {
     toast({
       status: 'success',
       duration: 4000,
-      isClosable: false,
       title: title ?? 'Success!',
       description: description ?? 'Your settings was updated!',
       icon: (


### PR DESCRIPTION
# Description
Adds a manual close option for toasts, preventing interactive elements from being blocked while the toast is visible. This ensures the user is not forced to wait for the toast to close automatically to continue navigation.

# Summary
- Added manual close option for toasts (close button / dismiss action)
- Adjusted toast behavior to avoid blocking 
- UI interaction Ensured toasts still auto-close when not dismissed manually

# Screenshots
<img width="1914" height="905" alt="example-1" src="https://github.com/user-attachments/assets/24659a58-41ac-4c7c-a88f-4d950cff5c08" />
<img width="1915" height="903" alt="example-2" src="https://github.com/user-attachments/assets/aa98fe7f-02f0-4f2c-bef0-92972e9d75df" />

Video: [Link](https://jam.dev/c/9f6492ba-1855-4582-9aeb-a57b2e3bdf16)

# Checklist
- [x] I reviewed my PR code before submitting
- [x] I ensured that the implementation is working correctly and did not impact other parts of the app
- [ ] I implemented error handling for all actions/requests and verified how they will be displayed in the UI (or there was no error handling needed).
- [x] I mentioned the PR link in the task