### PR TITLE
FEAT: hide balance modal accounts

### DIFF
--- a/src/layouts/dapp/header.tsx
+++ b/src/layouts/dapp/header.tsx
@@ -11,14 +11,14 @@ interface HeaderProps {
   title: string;
   description?: string;
   onClose?: () => void;
-  hidleBalance?: boolean;
+  hiddenBalance?: boolean;
 }
 
 const Header = ({
   title,
   description,
   onClose = window.close,
-  hidleBalance = false,
+  hiddenBalance = false,
 }: HeaderProps) => {
   const { renderCloseIcon } = useHeader();
   const {
@@ -54,7 +54,7 @@ const Header = ({
           )}
         </VStack>
 
-        {hidleBalance && (
+        {hiddenBalance && (
           <IconTooltipButton
             tooltipContent={visibleBalance ? 'Hide Balance' : 'Show Balance'}
             buttonProps={{

--- a/src/modules/dapp/pages/VaultConnector.tsx
+++ b/src/modules/dapp/pages/VaultConnector.tsx
@@ -72,7 +72,7 @@ const VaultConnector = () => {
       <Dapp.ScrollableContent isLoading={isLoadingVaults}>
         <CreateVaultDialog open={isOpen} onOpenChange={onOpenChange} />
 
-        <Dapp.Header title="Accounts" hidleBalance={true} />
+        <Dapp.Header title="Accounts" hiddenBalance={true} />
 
         <VStack w="full" gap={2}>
           {vaults?.map((vault) => {


### PR DESCRIPTION
# Description
Add the hide balance icon to the account selection modal in the connector flow, ensuring visual and functional consistency with the rest of the application.

# Summary
- Added the hide balance icon to the account selection modal in the connector flow
- Ensured consistent behavior with other application flows
- Implemented toggle functionality to hide/show account balances within the modal

# Screenshots
Video: [Link](https://jam.dev/c/6b6c623f-59b8-4bac-9dc0-93518caf5d17)
<img width="1913" height="1020" alt="example-1" src="https://github.com/user-attachments/assets/64f4e325-3116-4a8f-a9d0-6853c20ff8df" />
<img width="1908" height="1008" alt="example-2" src="https://github.com/user-attachments/assets/c89b438d-55c8-4d4c-a602-ee67845539c7" />


# Checklist
- [x] I reviewed my PR code before submitting
- [x] I ensured that the implementation is working correctly and did not impact other parts of the app
- [ ] I implemented error handling for all actions/requests and verified how they will be displayed in the UI (or there was no error handling needed).
- [x] I mentioned the PR link in the task