### PR TITLE
FEAT: hide balance change account

### DIFF
--- a/src/modules/vault/components/modal/index.tsx
+++ b/src/modules/vault/components/modal/index.tsx
@@ -4,13 +4,17 @@ import {
   DrawerRootProps,
   Field,
   floatingStyles,
+  Icon,
   Input,
   Loader,
   Text,
   VStack,
 } from 'bako-ui';
 
-import { CustomSkeleton, Dialog } from '@/components';
+import { CustomSkeleton, Dialog, IconTooltipButton } from '@/components';
+import { EyeCloseIcon } from '@/components/icons/eye-close';
+import { EyeOpenIcon } from '@/components/icons/eye-open';
+import { useWorkspaceContext } from '@/modules';
 import { useDisclosure } from '@/modules/core/hooks/useDisclosure';
 
 import { CreateVaultDialog } from '../dialog';
@@ -38,6 +42,19 @@ const VaultListModal = ({
     isOpen: props.open,
     onCloseAll,
   });
+
+  const {
+    workspaceInfos: {
+      infos: { visibleBalance },
+      handlers: { setVisibleBalance },
+    },
+  } = useWorkspaceContext();
+
+  const EyeIcon = visibleBalance ? EyeOpenIcon : EyeCloseIcon;
+
+  const handleToggleBalanceVisibility = () => {
+    setVisibleBalance(!visibleBalance);
+  };
 
   const {
     isOpen: isCreateVaultModalOpen,
@@ -88,7 +105,7 @@ const VaultListModal = ({
             borderBottomWidth={1}
             borderColor="gray.550"
           >
-            <Field.Root>
+            <Field.Root display="flex" alignItems="center" flexDirection="row">
               <Box position="relative" w="full">
                 <Input
                   placeholder=" "
@@ -106,6 +123,24 @@ const VaultListModal = ({
                   Search
                 </Field.Label>
               </Box>
+              <IconTooltipButton
+                tooltipContent={
+                  visibleBalance ? 'Hide Balance' : 'Show Balance'
+                }
+                buttonProps={{
+                  boxSize: '38px',
+                  minW: '38px',
+                  borderRadius: '6px',
+                  bg: 'gray.600',
+                }}
+                onClick={handleToggleBalanceVisibility}
+              >
+                <Icon
+                  as={EyeIcon}
+                  color="gray.200"
+                  w={visibleBalance ? '16px' : '12px'}
+                />
+              </IconTooltipButton>
             </Field.Root>
           </Box>
 


### PR DESCRIPTION
# Description
Extends the existing hide balance functionality to the account selection list in the "Select Account" modal on the sidebar, ensuring user privacy during navigation or screen sharing.

# Summary
- Added a toggle button to hide/show balances in the account selector
- Ensured the balance mask is applied to all accounts listed in the selector

# Screenshots
<img width="1917" height="908" alt="example-1" src="https://github.com/user-attachments/assets/99d2d529-e2c0-4da4-b575-f4cbed7bc439" />


# Checklist
- [x] I reviewed my PR code before submitting
- [x] I ensured that the implementation is working correctly and did not impact other parts of the app
- [ ] I implemented error handling for all actions/requests and verified how they will be displayed in the UI (or there was no error handling needed).
- [x] I mentioned the PR link in the task