### PR TITLE
FIX: passkey signup begin button disabled

### DIFF
--- a/src/modules/auth/hooks/signIn/useWebAuthnSignIn.ts
+++ b/src/modules/auth/hooks/signIn/useWebAuthnSignIn.ts
@@ -139,7 +139,7 @@ const useWebAuthnSignIn = (
       handleAction: handleLogin,
       handleActionUsingEnterKey: undefined,
       isLoading: isSigningIn,
-      isDisabled: isLoginModeBtnDisabled,
+      isDisabled: isSigningIn,
       disableInput: false,
       isLoadingOptions: false,
     },


### PR DESCRIPTION
# Description
Fixes an issue where the "Begin" button remained disabled in the welcome modal after completing the signup flow using passkey. This prevented users from being redirected to the home screen, effectively blocking access to the application after successful registration.

# Summary
- Fixed state handling after successful passkey signup Ensured
- "Begin" button is enabled once registration is completed
-  Prevented user from being blocked in the welcome modal
-  Validated redirection to home screen after clicking "Begin"

# Screenshots
Video: [**Link**](https://jam.dev/c/781566c3-7e87-4c4b-8985-36be79ad32c4)
<img width="1917" height="905" alt="example-1" src="https://github.com/user-attachments/assets/451953d5-6e92-4d7a-9d7b-8c996af989e5" />


# Checklist
- [x] I reviewed my PR code before submitting
- [x] I ensured that the implementation is working correctly and did not impact other parts of the app
- [ ] I implemented error handling for all actions/requests and verified how they will be displayed in the UI (or there was no error handling needed).
- [x] I mentioned the PR link in the task