### PR TITLE
FIX: clear query cache and remove placeholder data on logout

### DIFF
--- a/src/layouts/dashboard/header.tsx
+++ b/src/layouts/dashboard/header.tsx
@@ -126,10 +126,6 @@ const UserBox = () => {
   const logout = async () => {
     setIsLoggingOut(true);
     try {
-      //TODO: Cancel any outgoing requests to avoid race conditions
-      await queryClient.cancelQueries();
-      // TODO: Clear all cached data (assets, user info, etc.)
-      queryClient.clear();
       authDetails.userInfos?.type.type === TypeUser.FUEL &&
         authDetails.userInfos?.type.name !== EConnectors.FULLET &&
         (await fuel.disconnect());

--- a/src/modules/auth/hooks/useAuth.ts
+++ b/src/modules/auth/hooks/useAuth.ts
@@ -58,8 +58,9 @@ const useAuth = (): IUseAuthReturn => {
       callback?.();
     }
 
-    setTimeout(() => {
+    setTimeout(async () => {
       clearAuthCookies();
+      await queryClient.cancelQueries();
       queryClient.clear();
 
       const queryParams = generateRedirectQueryParams({
@@ -77,6 +78,7 @@ const useAuth = (): IUseAuthReturn => {
     localStorage.setItem(BAKO_SUPPORT_SEARCH, 'false');
     window.dispatchEvent(new Event('bako-storage-change'));
     clearAuthCookies();
+    await queryClient.cancelQueries();
     queryClient.clear();
     navigate('/?expired=true');
   };
@@ -100,7 +102,7 @@ const useAuth = (): IUseAuthReturn => {
       return { type: TypeUser.WEB_AUTHN, name: EConnectors.WEB_AUTHN };
     }
 
-    const isEvm = infos?.type as unknown as TypeUser == TypeUser.EVM;
+    const isEvm = (infos?.type as unknown as TypeUser) == TypeUser.EVM;
     if (isEvm) {
       return { type: TypeUser.EVM, name: EConnectors.EVM };
     }


### PR DESCRIPTION
# Description
This PR fixes a data leakage issue where assets from a previously logged-in wallet were temporarily displayed when switching accounts or logging in with a different wallet provider (e.g., Fuel to Passkey). This was particularly visible on slow network connections (3G). By clearing the global query cache and removing stale data persistence, we ensure that the UI always displays loading states or skeletons until the current wallet's data is fully fetched.

# Summary
- Removed placeholderData from useHasReservedCoins hook to prevent stale data from being displayed during predicateId transitions.
- Implemented queryClient.clear() in the logout flow to wipe all sensitive wallet data from the application memory.
- Added queryClient.cancelQueries() during logout to prevent race conditions from pending requests resolving after the session ends.
- Ensured that the UI correctly triggers loading/skeleton states when switching between different wallet contexts.

# Screenshots
Video: [Link](https://jam.dev/c/cbf18b01-6b20-4d86-bd52-8d3daa753562)

# Checklist
- [x] I reviewed my PR code before submitting
- [x] I ensured that the implementation is working correctly and did not impact other parts of the app
- [ ] I implemented error handling for all actions/requests and verified how they will be displayed in the UI (or there was no error handling needed).
- [x] I mentioned the PR link in the task