### PR TITLE
feat: mark Bridge deposit as coming soon and disable click action

### DIFF
--- a/src/components/addAssetsDialog/index.tsx
+++ b/src/components/addAssetsDialog/index.tsx
@@ -97,7 +97,9 @@ const AddAssetsDialog = ({
             description="Transfer between different networks."
             iconSize="18px"
             icon={BridgeIcon}
-            onClick={() => handleRedirectToMainNet()}
+            commingSoon
+            /* Hidden until release */
+            // onClick={() => handleRedirectToMainNet()}
           />
           <WelcomeCard
             title="PURCHASE"

--- a/src/components/welcomeDialog/index.tsx
+++ b/src/components/welcomeDialog/index.tsx
@@ -87,8 +87,9 @@ const WelcomeDialog = ({
             description="Crypto from Ethereum network to Fuel mainnet."
             icon={BridgeIcon}
             iconSize="18px"
-            commingSoon={isTestnet}
-            onClick={isTestnet ? undefined : () => handleRedirectToMainNet()}
+            commingSoon
+            /* Hidden until release */
+            // onClick={isTestnet ? undefined : () => handleRedirectToMainNet()}
             isMobile={isMobile}
           />
           <WelcomeCard

--- a/src/modules/vault/layout/sidebar.tsx
+++ b/src/modules/vault/layout/sidebar.tsx
@@ -9,7 +9,6 @@ import {
   BakoGarageBanner,
   BakoIcon,
   Banner,
-  BridgeIcon,
   Carousel,
   CoinsIcon,
   ExchangeIcon,
@@ -141,24 +140,23 @@ const Sidebar = memo(({ onDrawer, ...rest }: SidebarProps) => {
               Assets
             </SidebarMenu.Title>
           </SidebarMenu.Container>
-
-          <SidebarMenu.Container
-            isActive={menuItems.bridge}
-            onClick={() =>
-              handleNavigate(
-                Pages.bridge({
-                  workspaceId: route.params.workspaceId!,
-                  vaultId: route.params.vaultId!,
-                }),
-              )
-            }
-          >
-            <SidebarMenu.Icon as={BridgeIcon} isActive={false} />
-            <SidebarMenu.Title isActive={menuItems.bridge}>
-              Bridge
-            </SidebarMenu.Title>
-          </SidebarMenu.Container>
-
+          {/* Hidden until release */}
+          {/*<SidebarMenu.Container*/}
+          {/*  isActive={menuItems.bridge}*/}
+          {/*  onClick={() =>*/}
+          {/*    handleNavigate(*/}
+          {/*      Pages.bridge({*/}
+          {/*        workspaceId: route.params.workspaceId!,*/}
+          {/*        vaultId: route.params.vaultId!,*/}
+          {/*      }),*/}
+          {/*    )*/}
+          {/*  }*/}
+          {/*>*/}
+          {/*  <SidebarMenu.Icon as={BridgeIcon} isActive={false} />*/}
+          {/*  <SidebarMenu.Title isActive={menuItems.bridge}>*/}
+          {/*    Bridge*/}
+          {/*  </SidebarMenu.Title>*/}
+          {/*</SidebarMenu.Container>*/}
           {/* Hidden until release */}
           {/* <SidebarMenu.Container
             isActive={menuItems.buySell}


### PR DESCRIPTION
# Description
Update the Bridge option in the Vault deposit flow to reflect that the feature will be released later.

# Summary
- Added the "Coming soon" tag to the Bridge option.
- Disabled the click action for the Bridge option.
- Removed the Bridge option from the sidebar.

# Screenshots
<img width="1916" height="907" alt="example-1" src="https://github.com/user-attachments/assets/d9ebe70c-756b-4abc-a50f-a347120e489c" />
<img width="1916" height="903" alt="example-2" src="https://github.com/user-attachments/assets/7a7cd99f-eb42-49d9-8e2b-31580a59b438" />


# Checklist
- [x] I reviewed my PR code before submitting
- [x] I ensured that the implementation is working correctly and did not impact other parts of the app
- [ ] I implemented error handling for all actions/requests and verified how they will be displayed in the UI (or there was no error handling needed).
- [x] I mentioned the PR link in the task