### PR TITLE
FIX: invalidate list queries when vault is activated/dectivated

### DIFF
--- a/src/modules/vault/components/VaultCard.tsx
+++ b/src/modules/vault/components/VaultCard.tsx
@@ -21,7 +21,11 @@ import { CopyTopMenuIcon } from '@/components/icons/copy-top-menu';
 import { EyeCloseIcon } from '@/components/icons/eye-close';
 import { EyeOpenIcon } from '@/components/icons/eye-open';
 import { queryClient } from '@/config';
-import { useHasReservedCoins, USER_ALLOCATION_QUERY_KEY } from '@/modules';
+import {
+  useHasReservedCoins,
+  USER_ALLOCATION_QUERY_KEY,
+  USER_VAULTS_QUERY_KEY,
+} from '@/modules';
 import { AddressUtils } from '@/modules/core';
 import { useWorkspaceContext } from '@/modules/workspace/hooks';
 
@@ -47,8 +51,10 @@ export const VaultCard = memo(function VaultCard({
   ...rest
 }: VaultCardProps) {
   const {
+    authDetails: {
+      userInfos: { address: userAddress },
+    },
     screenSizes: { isExtraSmall },
-    userVaults,
     workspaceInfos: {
       requests: { latestPredicates },
       infos: { visibleBalance },
@@ -65,7 +71,10 @@ export const VaultCard = memo(function VaultCard({
   const { mutate: toogleVisibility, isPending } = useMutation({
     mutationFn: VaultService.toggleVisibility,
     onSuccess: () => {
-      userVaults.request.refetch();
+      queryClient.invalidateQueries({
+        queryKey: [USER_VAULTS_QUERY_KEY, userAddress],
+        exact: false,
+      });
       latestPredicates.refetch();
       queryClient.invalidateQueries({
         queryKey: [USER_ALLOCATION_QUERY_KEY],

--- a/src/modules/vault/hooks/useUserVaultRequest.ts
+++ b/src/modules/vault/hooks/useUserVaultRequest.ts
@@ -5,7 +5,7 @@ import { DEFAULT_INITIAL_PAGE_PARAM } from '@/utils/constants';
 
 import { GetAllPredicatesPayload, VaultService } from '../services';
 
-const USER_VAULTS_QUERY_KEY = 'predicate/by-user-address';
+export const USER_VAULTS_QUERY_KEY = 'predicate/by-user-address';
 
 const useUserVaultRequest = (
   userAddress: string,


### PR DESCRIPTION
# Description
After reactivating a previously deactivated account, it does not automatically return to the list of active accounts. For the account to reappear correctly in the list, you need to reload the page.

# Summary
- Invalidate user vaults list query when vault is activated/deactivated.

# Screenshots
https://jam.dev/c/9af126bf-257b-495c-a27f-38fe5e82c9af

# Checklist
- [x] I reviewed my PR code before submitting
- [x] I ensured that the implementation is working correctly and did not impact other parts of the app
- [ ] I implemented error handling for all actions/requests and verified how they will be displayed in the UI (or there was no error handling needed).
- [ ] I mentioned the PR link in the task