### PR TITLE
fix(logout): clear query client cache and cancel queries after logout request

### DIFF
--- a/src/layouts/dashboard/header.tsx
+++ b/src/layouts/dashboard/header.tsx
@@ -26,7 +26,6 @@ import { AddressBook2Icon } from '@/components/icons/address-book-2';
 import { DisconnectIcon } from '@/components/icons/disconnect';
 import { FeedbackIcon } from '@/components/icons/feedback';
 import { SettingsTopMenuIcon } from '@/components/icons/settings-top-menu';
-import { queryClient } from '@/config';
 import {
   IDefaultMessage,
   Pages,
@@ -110,10 +109,6 @@ const UserBox = () => {
   const logout = useCallback(async () => {
     setIsLoggingOut(true);
     try {
-      //TODO: Cancel any outgoing requests to avoid race conditions
-      await queryClient.cancelQueries();
-      // TODO: Clear all cached data (assets, user info, etc.)
-      queryClient.clear();
       authDetails.userInfos?.type.type === TypeUser.FUEL &&
         authDetails.userInfos?.type.name !== EConnectors.FULLET &&
         (await fuel.disconnect());

--- a/src/modules/auth/hooks/useAuth.ts
+++ b/src/modules/auth/hooks/useAuth.ts
@@ -57,8 +57,9 @@ const useAuth = (): IUseAuthReturn => {
       callback?.();
     }
 
-    setTimeout(() => {
+    setTimeout(async () => {
       clearAuthCookies();
+      await queryClient.cancelQueries();
       queryClient.clear();
 
       const queryParams = generateRedirectQueryParams({
@@ -77,6 +78,7 @@ const useAuth = (): IUseAuthReturn => {
     localStorage.setItem(BAKO_SUPPORT_SEARCH, 'false');
     window.dispatchEvent(new Event('bako-storage-change'));
     clearAuthCookies();
+    await queryClient.cancelQueries();
     queryClient.clear();
     navigate('/?expired=true');
   };


### PR DESCRIPTION
# Description
Clearing the cache and canceling queries before the logout request was causing some layout breaks.

# Summary
- Clears cache and cancels queries after making logout request to avoid layout breaks

# Screenshots
https://jam.dev/c/cd0f322c-29ec-48ac-82a8-272254a8ef83

# Checklist
- [x] I reviewed my PR code before submitting
- [x] I ensured that the implementation is working correctly and did not impact other parts of the app
- [ ] I implemented error handling for all actions/requests and verified how they will be displayed in the UI (or there was no error handling needed).
- [x] I mentioned the PR link in the task