### PR TITLE
release: promote staging to prod — bakosafe 0.6.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@web3modal/wagmi": "5.0.0",
     "axios": "^1.5.0",
     "bako-ui": "0.5.7",
-    "bakosafe": "0.6.2",
+    "bakosafe": "0.6.3",
     "bech32": "^2.0.0",
     "crypto-js": "4.2.0",
     "date-fns": "^4.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,8 +69,8 @@ importers:
         specifier: 0.5.7
         version: 0.5.7(@chakra-ui/react@3.28.0(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(recharts@3.3.0(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react-is@16.13.1)(react@19.2.0)(redux@5.0.1))
       bakosafe:
-        specifier: 0.6.2
-        version: 0.6.2(bufferutil@4.0.9)(fuels@0.103.0(vitest@3.0.9(@types/debug@4.1.12)(@types/node@20.5.1)(terser@5.43.1)))(typescript@5.4.5)(utf-8-validate@5.0.10)(zod@3.25.76)
+        specifier: 0.6.3
+        version: 0.6.3(bufferutil@4.0.9)(fuels@0.103.0(vitest@3.0.9(@types/debug@4.1.12)(@types/node@20.5.1)(terser@5.43.1)))(typescript@5.4.5)(utf-8-validate@5.0.10)(zod@3.25.76)
       bech32:
         specifier: ^2.0.0
         version: 2.0.0
@@ -3250,8 +3250,8 @@ packages:
       react: ^18.0.0 || ^19.0.0
       react-dom: ^18.0.0 || ^19.0.0
 
-  bakosafe@0.6.2:
-    resolution: {integrity: sha512-oLFg0/BUZnchWNr9I6i7lyGjvtPVgOcq+tDiIf3eTgGF/F5the+9CP4YV50Sx5aioESMb9AIncJj4Xa4fd5Xgg==}
+  bakosafe@0.6.3:
+    resolution: {integrity: sha512-nEfaHc7S5LGGe2la4gOwq/VV5eSFnxYk4N093WfVPT6D1dxA/5W/E963N/ag9Ma5Q3O7XKi1BSFDezqp0b94cg==}
     peerDependencies:
       fuels: ^0.102.0
 
@@ -13495,7 +13495,7 @@ snapshots:
     transitivePeerDependencies:
       - recharts
 
-  bakosafe@0.6.2(bufferutil@4.0.9)(fuels@0.103.0(vitest@3.0.9(@types/debug@4.1.12)(@types/node@20.5.1)(terser@5.43.1)))(typescript@5.4.5)(utf-8-validate@5.0.10)(zod@3.25.76):
+  bakosafe@0.6.3(bufferutil@4.0.9)(fuels@0.103.0(vitest@3.0.9(@types/debug@4.1.12)(@types/node@20.5.1)(terser@5.43.1)))(typescript@5.4.5)(utf-8-validate@5.0.10)(zod@3.25.76):
     dependencies:
       '@ethereumjs/util': 9.0.3
       '@ethersproject/bytes': 5.7.0


### PR DESCRIPTION
## Summary
- Upgrade bakosafe from 0.6.2 to 0.6.3
- maxFee multiplier increased from 2.5x to 4x to handle gas price spikes on mainnet

## Context
Transactions were failing with "max fee can't cover transaction cost" due to gas price spikes caused by bot activity. The 4x multiplier provides adequate margin.

## PRs included
- infinitybase/bako-safe-ui#868 — bakosafe 0.6.3 upgrade