### PR TITLE
fix: handle async tx submission result via socket events

### DIFF
--- a/src/modules/transactions/hooks/events/useTransactionsSocketListener.ts
+++ b/src/modules/transactions/hooks/events/useTransactionsSocketListener.ts
@@ -80,9 +80,46 @@ export const useTransactionSocketListener = (key?: QueryKey) => {
     });
   }, [queryClient]);
 
+  // When the worker sends minimal tx data (no full transaction object),
+  // the updateTransactions handler skips the cache replacement.
+  // This handler invalidates the relevant queries so React Query refetches
+  // the fully formatted transaction from the API.
+  const handleWorkerUpdate = useCallback(
+    (event: ITransactionReactQueryUpdate) => {
+      if (!event?.transaction) return;
+
+      // Detect minimal payload from worker (missing `name` field)
+      if (!event.transaction.name) {
+        const workspaceId = userInfos.workspace?.id ?? '';
+        const { predicateId, id } = event.transaction;
+
+        queryClient.invalidateQueries({
+          queryKey: HomeQueryKey.HOME_WORKSPACE(workspaceId),
+        });
+        queryClient.invalidateQueries({
+          queryKey:
+            vaultInfinityQueryKey.VAULT_TRANSACTION_LIST_PAGINATION_QUERY_KEY(
+              predicateId,
+            ),
+        });
+        queryClient.invalidateQueries({
+          queryKey:
+            WorkspacesQueryKey.TRANSACTION_LIST_PAGINATION_QUERY_KEY(
+              workspaceId,
+            ),
+        });
+        queryClient.invalidateQueries({
+          queryKey: getTransactionHistoryQueryKey(id, predicateId),
+        });
+      }
+    },
+    [queryClient, userInfos],
+  );
+
   useSocketEvent<ITransactionReactQueryUpdate>(SocketEvents.TRANSACTION, [
     updateTransactions,
     updateHistory,
     handleSignaturePending,
+    handleWorkerUpdate,
   ]);
 };

--- a/src/modules/transactions/hooks/send/useSendTransaction.ts
+++ b/src/modules/transactions/hooks/send/useSendTransaction.ts
@@ -1,11 +1,14 @@
 import { TransactionStatus } from 'bakosafe';
+import { useCallback } from 'react';
 
 import { queryClient } from '@/config';
-import { useAuth } from '@/modules';
+import { SocketEvents, useAuth } from '@/modules';
 import { useBakoSafeTransactionSend, WitnessStatus } from '@/modules/core';
 import { ITransaction } from '@/modules/core/hooks/bakosafe/utils/types';
+import { useSocketEvent } from '@/modules/core/hooks/socket/useSocketEvent';
 import { useNotificationsStore } from '@/modules/notifications/store';
 import { TransactionService } from '@/modules/transactions/services';
+import { ITransactionReactQueryUpdate } from '@/modules/transactions/services/types';
 
 import { useTransactionToast } from '../../providers/toast';
 import { useTransactionState } from '../../states';
@@ -17,10 +20,43 @@ export type IUseSendTransaction = {
 
 const useSendTransaction = ({ onTransactionSuccess }: IUseSendTransaction) => {
   const { setHasNewNotification } = useNotificationsStore();
-  const { setIsCurrentTxPending } = useTransactionState();
+  const { isCurrentTxPending, setIsCurrentTxPending } = useTransactionState();
   const toast = useTransactionToast();
 
   const { userInfos } = useAuth();
+
+  // Listen for socket events to resolve the loading toast when the
+  // worker finishes processing the transaction asynchronously.
+  const handleSocketResult = useCallback(
+    async (event: ITransactionReactQueryUpdate) => {
+      if (!isCurrentTxPending.isPending) return;
+      if (!event?.transaction) return;
+      if (event.transaction.id !== isCurrentTxPending.transactionId) return;
+
+      const { id, status, predicateId } = event.transaction;
+
+      if (status === TransactionStatus.SUCCESS) {
+        const fullTx = await TransactionService.getById(id);
+        toast.success(fullTx);
+        setIsCurrentTxPending({ isPending: false, transactionId: '' });
+        queryClient.invalidateQueries({
+          queryKey: [TRANSACTION_HISTORY_QUERY_KEY, id, predicateId],
+        });
+        setHasNewNotification(true);
+      }
+
+      if (status === TransactionStatus.FAILED) {
+        toast.error(id, 'Transaction failed');
+        setIsCurrentTxPending({ isPending: false, transactionId: '' });
+        setHasNewNotification(true);
+      }
+    },
+    [isCurrentTxPending, setIsCurrentTxPending, toast, setHasNewNotification],
+  );
+
+  useSocketEvent<ITransactionReactQueryUpdate>(SocketEvents.TRANSACTION, [
+    handleSocketResult,
+  ]);
 
   const { mutate: sendTransaction } = useBakoSafeTransactionSend({
     onSuccess: (transaction: ITransaction) => {

--- a/src/modules/transactions/services/methods.ts
+++ b/src/modules/transactions/services/methods.ts
@@ -335,6 +335,10 @@ export class TransactionService {
 
     const { type, transaction } = event;
 
+    // Worker sends minimal tx data (id, status, hash, predicateId).
+    // Skip cache replacement — invalidateQueries handles the refetch.
+    if (!transaction?.name) return oldData;
+
     if (type !== '[CREATED]') {
       return {
         ...oldData,
@@ -357,6 +361,10 @@ export class TransactionService {
     if (!oldData) return oldData;
 
     const { type, transaction } = event;
+
+    // Worker sends minimal tx data — skip cache replacement
+    if (!transaction?.name) return oldData;
+
     const { pageParams, pages } = oldData;
 
     if (type !== '[CREATED]') {


### PR DESCRIPTION
## Summary
- Handle minimal transaction payload from worker socket events without corrupting React Query cache
- Resolve loading toast via socket when worker reports final tx status (SUCCESS/FAILED)
- Invalidate transaction queries on worker updates to trigger API refetch with full data

## Context
Transaction submission moved to async Bull queue in the API. The worker sends socket events with minimal data (`id`, `status`, `hash`, `predicateId`). These changes ensure the frontend handles this correctly without breaking UX.

## Changes
- `methods.ts`: guard against cache replacement with partial tx data
- `useTransactionsSocketListener.ts`: invalidate queries on minimal worker payload
- `useSendTransaction.ts`: listen for socket result to resolve loading toast